### PR TITLE
Proxy the Squiggle API server-side

### DIFF
--- a/client/src/utils/TipsAPI.js
+++ b/client/src/utils/TipsAPI.js
@@ -1,30 +1,23 @@
 import axios from "axios";
 
 const season = "2023";
-const fixtureUrlAll = `https://api.squiggle.com.au/?q=games;year=${season}`;
-const squiggleCallOptions = {
-  withCredentials: false,
-  // headers: {
-  //   Twin_Tips_Contact: "peter@agcorp.com.au",
-  // },
-};
+
+// Squiggle is reached through our own server, never directly: their terms forbid
+// visitors fetching from them, and they enforce it with an origin allowlist plus
+// a required User-Agent that a browser cannot set. See routes/squiggle.js.
 
 export default {
   getFixture: function () {
-    return axios.get(fixtureUrlAll, squiggleCallOptions);
+    return axios.get(`/api/squiggle/games?year=${season}`);
   },
 
   getRoundFixture: function (round) {
-    return axios.get(
-      `https://api.squiggle.com.au/?q=games;year=${season};round=${round}`,
-      squiggleCallOptions
-    );
+    return axios.get(`/api/squiggle/games?year=${season}&round=${round}`);
   },
 
   getModels: function (round) {
     return axios.get(
-      `https://api.squiggle.com.au/?q=tips;year=${season};round=${round};source=8`,
-      squiggleCallOptions
+      `/api/squiggle/tips?year=${season}&round=${round}&source=8`
     );
   },
 
@@ -38,10 +31,7 @@ export default {
   },
 
   getTeams: function () {
-    return axios.get(
-      "https://api.squiggle.com.au/?q=teams",
-      squiggleCallOptions
-    );
+    return axios.get("/api/squiggle/teams");
   },
 
   postTeams: function (data) {
@@ -53,10 +43,7 @@ export default {
   },
 
   getStandings: function () {
-    return axios.get(
-      "https://api.squiggle.com.au/?q=standings",
-      squiggleCallOptions
-    );
+    return axios.get("/api/squiggle/standings");
   },
 
   postStandings: function (data) {

--- a/routes/squiggle.js
+++ b/routes/squiggle.js
@@ -1,0 +1,124 @@
+// Server-side proxy for the Squiggle API.
+//
+// Squiggle's terms forbid "a website that makes visitors fetch directly from the
+// Squiggle API themselves", and they enforce it: requests carrying an Origin
+// header from an origin they haven't allowlisted get a 403, and a browser cannot
+// set the identifying User-Agent they require. So every Squiggle call has to
+// originate here.
+//
+// They also ask callers to "cache and re-use data appropriately", hence the
+// in-memory cache below.
+
+const express = require("express");
+const router = express.Router();
+const { requireAuth } = require("../middleware/auth");
+
+const SQUIGGLE_BASE = "https://api.squiggle.com.au/";
+
+// Squiggle require a UserAgent identifying the app and carrying a contact
+// address, e.g. "Dan's Tipping Comp - dan@example.com". Kept in the environment
+// rather than in source: this repo is public, and a hardcoded address would be
+// published to anyone scraping GitHub for email addresses.
+const CONTACT = process.env.SQUIGGLE_CONTACT;
+const USER_AGENT = CONTACT ? `Twin Tips - ${CONTACT}` : "Twin Tips";
+
+if (!CONTACT) {
+  console.warn(
+    "SQUIGGLE_CONTACT is not set - Squiggle asks for a contact address in the " +
+      "UserAgent and may refuse or ban requests without one."
+  );
+}
+
+// Only these query types may be proxied - the route must not become an open
+// relay that forwards arbitrary URLs.
+const ALLOWED_QUERIES = ["games", "teams", "standings", "tips"];
+
+// Only these parameters are forwarded, and each must be a plain integer.
+const ALLOWED_PARAMS = ["year", "round", "source"];
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map();
+
+const buildUrl = (query, params) => {
+  // Squiggle separates parameters with semicolons: ?q=games;year=2023;round=5
+  const parts = [`q=${query}`];
+  for (const key of ALLOWED_PARAMS) {
+    if (params[key] !== undefined) parts.push(`${key}=${params[key]}`);
+  }
+  return `${SQUIGGLE_BASE}?${parts.join(";")}`;
+};
+
+const fetchSquiggle = async (url) => {
+  const cached = cache.get(url);
+  if (cached && Date.now() < cached.expires) {
+    return cached.promise;
+  }
+
+  const promise = (async () => {
+    const response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Squiggle responded ${response.status}`);
+    }
+
+    const body = await response.json();
+
+    // A 200 can still carry an error, e.g. {"error":"bad_UA"} when the
+    // UserAgent is rejected. Treat that as a failure rather than caching it.
+    const payload = Array.isArray(body[Object.keys(body)[0]])
+      ? body[Object.keys(body)[0]]
+      : null;
+    if (payload && payload.length === 1 && payload[0] && payload[0].error) {
+      throw new Error(`Squiggle rejected the request: ${payload[0].error}`);
+    }
+
+    return body;
+  })();
+
+  // Cached before it settles so parallel callers share one upstream request.
+  cache.set(url, { promise, expires: Date.now() + CACHE_TTL_MS });
+
+  try {
+    return await promise;
+  } catch (err) {
+    // Never leave a rejection cached, or the failure sticks for the whole TTL.
+    cache.delete(url);
+    throw err;
+  }
+};
+
+router.get("/:query", requireAuth, async (req, res) => {
+  const { query } = req.params;
+
+  if (!ALLOWED_QUERIES.includes(query)) {
+    return res
+      .status(400)
+      .json({ success: false, message: `Unsupported query type: ${query}` });
+  }
+
+  const params = {};
+  for (const key of ALLOWED_PARAMS) {
+    const value = req.query[key];
+    if (value === undefined) continue;
+    if (!/^\d+$/.test(String(value))) {
+      return res
+        .status(400)
+        .json({ success: false, message: `${key} must be a number.` });
+    }
+    params[key] = String(value);
+  }
+
+  try {
+    const data = await fetchSquiggle(buildUrl(query, params));
+    res.status(200).json(data);
+  } catch (err) {
+    console.error("Squiggle proxy failed:", err.message);
+    res
+      .status(502)
+      .json({ success: false, message: "Unable to reach the Squiggle API." });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -46,6 +46,7 @@ async function start() {
   app.use(passport.session());
 
   app.use("/api/auth", require("./routes/api/auth"));
+  app.use("/api/squiggle", require("./routes/squiggle"));
 
   // Import routes and give the server access to them.
   require("./routes/api-routes.js")(app);


### PR DESCRIPTION
The Tips page was blank: every Squiggle call was made from the visitor's browser, and Squiggle now refuses those. Two independent blocks, both unfixable from the client:

- Requests carrying an Origin header from an origin Squiggle has not allowlisted get a 403. Confirmed by experiment: Origin squiggle.com.au returns 200, localhost and twin-tips.herokuapp.com return 403, and no Origin header at all returns 200. Their old Heroku domain is refused too, so this was already broken before the migration.
- Squiggle require a UserAgent identifying the app with a contact address; default library agents get {"error":"bad_UA"}. A browser cannot set User-Agent.

This was never permitted anyway. Their documentation asks callers not to "build a website that makes visitors fetch directly from the Squiggle API themselves" - which is exactly what this app did.

routes/squiggle.js proxies games, teams, standings and tips. Query types and parameters are whitelisted, and parameters must be integers, so the route cannot be turned into an open relay. Responses are cached for five minutes, satisfying their request to "cache and re-use data appropriately"; the cache stores the in-flight promise so concurrent callers share one upstream request, and drops rejections rather than holding a failure for the whole TTL. A 200 carrying an error body is treated as a failure. The routes sit behind requireAuth like the rest of the API.

The contact address comes from SQUIGGLE_CONTACT rather than source: this repository is public, and a hardcoded address would be published to anyone scraping GitHub. Render will need the variable set; without it the server logs a warning and sends a UserAgent with no contact.

Verified: unauthenticated requests get 401, unsupported query types and non-numeric parameters get 400, and the Tips page renders all nine round 23 fixtures with model predictions from a clean browser session with no console errors and no request leaving for api.squiggle.com.au. Repeat requests served from cache in 13ms against 183ms upstream.