### PR TITLE
Derive the season and round on the server

### DIFF
--- a/models/Fixtures.js
+++ b/models/Fixtures.js
@@ -11,6 +11,13 @@ const fixtureSchema = new Schema({
   round: {
     type: Number,
   },
+  // Squiggle's label for the round, e.g. "Round 12", "Wildcard Finals",
+  // "Preliminary Finals". This is the only dependable way to tell a finals
+  // round from a home-and-away one: is_final comes back 0 for every 2026 game,
+  // including the Grand Final.
+  roundname: {
+    type: String,
+  },
   venue: {
     type: String,
   },
@@ -50,11 +57,15 @@ const fixtureSchema = new Schema({
   ascore: {
     type: Number,
   },
+  // Not a flag: Squiggle sends a code for the finals type - 0 home-and-away,
+  // 7 wildcard, 2/3 week one, 4 semi, 5 preliminary, 6 grand final. Declaring
+  // it Boolean made Mongoose reject the real values with a CastError. Any
+  // non-zero value means finals.
   is_final: {
-    type: Boolean,
+    type: Number,
   },
   is_grand_final: {
-    type: Boolean,
+    type: Number,
   },
   winner: {
     type: String,

--- a/routes/season.js
+++ b/routes/season.js
@@ -1,0 +1,56 @@
+const express = require("express");
+const router = express.Router();
+const { requireAuth, requireAdmin } = require("../middleware/auth");
+const season = require("../services/season");
+const seasonSync = require("../services/seasonSync");
+
+// Single source of truth for which season and round the app is in, replacing
+// the season constants that were hardcoded - and disagreeing - across the
+// client.
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const state = await season.getSeasonState(req.query.season);
+    res.status(200).json(state);
+  } catch (err) {
+    console.error("Failed to resolve season state:", err.message);
+    res
+      .status(500)
+      .json({ success: false, message: "Unable to determine the season." });
+  }
+});
+
+// Which seasons have fixtures, newest first.
+router.get("/available", requireAuth, async (req, res) => {
+  try {
+    res.status(200).json({ seasons: await season.getAvailableSeasons() });
+  } catch (err) {
+    console.error("Failed to list seasons:", err.message);
+    res
+      .status(500)
+      .json({ success: false, message: "Unable to list seasons." });
+  }
+});
+
+// Pulls a season from Squiggle into the database. Admin-only: it is the one
+// route that rewrites shared fixture, ladder and team data.
+router.post("/sync", requireAdmin, async (req, res) => {
+  const year = Number(req.body.year);
+
+  if (!Number.isInteger(year)) {
+    return res
+      .status(400)
+      .json({ success: false, message: "year must be a number." });
+  }
+
+  try {
+    const result = await seasonSync.syncSeason(year);
+    res.status(200).json({ success: true, ...result });
+  } catch (err) {
+    console.error("Season sync failed:", err.message);
+    res
+      .status(502)
+      .json({ success: false, message: `Sync failed: ${err.message}` });
+  }
+});
+
+module.exports = router;

--- a/routes/squiggle.js
+++ b/routes/squiggle.js
@@ -1,33 +1,15 @@
-// Server-side proxy for the Squiggle API.
+// Browser-facing proxy for the Squiggle API.
 //
 // Squiggle's terms forbid "a website that makes visitors fetch directly from the
 // Squiggle API themselves", and they enforce it: requests carrying an Origin
 // header from an origin they haven't allowlisted get a 403, and a browser cannot
 // set the identifying User-Agent they require. So every Squiggle call has to
-// originate here.
-//
-// They also ask callers to "cache and re-use data appropriately", hence the
-// in-memory cache below.
+// originate on the server. The shared client lives in services/squiggle.js.
 
 const express = require("express");
 const router = express.Router();
 const { requireAuth } = require("../middleware/auth");
-
-const SQUIGGLE_BASE = "https://api.squiggle.com.au/";
-
-// Squiggle require a UserAgent identifying the app and carrying a contact
-// address, e.g. "Dan's Tipping Comp - dan@example.com". Kept in the environment
-// rather than in source: this repo is public, and a hardcoded address would be
-// published to anyone scraping GitHub for email addresses.
-const CONTACT = process.env.SQUIGGLE_CONTACT;
-const USER_AGENT = CONTACT ? `Twin Tips - ${CONTACT}` : "Twin Tips";
-
-if (!CONTACT) {
-  console.warn(
-    "SQUIGGLE_CONTACT is not set - Squiggle asks for a contact address in the " +
-      "UserAgent and may refuse or ban requests without one."
-  );
-}
+const squiggle = require("../services/squiggle");
 
 // Only these query types may be proxied - the route must not become an open
 // relay that forwards arbitrary URLs.
@@ -35,59 +17,6 @@ const ALLOWED_QUERIES = ["games", "teams", "standings", "tips"];
 
 // Only these parameters are forwarded, and each must be a plain integer.
 const ALLOWED_PARAMS = ["year", "round", "source"];
-
-const CACHE_TTL_MS = 5 * 60 * 1000;
-const cache = new Map();
-
-const buildUrl = (query, params) => {
-  // Squiggle separates parameters with semicolons: ?q=games;year=2023;round=5
-  const parts = [`q=${query}`];
-  for (const key of ALLOWED_PARAMS) {
-    if (params[key] !== undefined) parts.push(`${key}=${params[key]}`);
-  }
-  return `${SQUIGGLE_BASE}?${parts.join(";")}`;
-};
-
-const fetchSquiggle = async (url) => {
-  const cached = cache.get(url);
-  if (cached && Date.now() < cached.expires) {
-    return cached.promise;
-  }
-
-  const promise = (async () => {
-    const response = await fetch(url, {
-      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
-    });
-
-    if (!response.ok) {
-      throw new Error(`Squiggle responded ${response.status}`);
-    }
-
-    const body = await response.json();
-
-    // A 200 can still carry an error, e.g. {"error":"bad_UA"} when the
-    // UserAgent is rejected. Treat that as a failure rather than caching it.
-    const payload = Array.isArray(body[Object.keys(body)[0]])
-      ? body[Object.keys(body)[0]]
-      : null;
-    if (payload && payload.length === 1 && payload[0] && payload[0].error) {
-      throw new Error(`Squiggle rejected the request: ${payload[0].error}`);
-    }
-
-    return body;
-  })();
-
-  // Cached before it settles so parallel callers share one upstream request.
-  cache.set(url, { promise, expires: Date.now() + CACHE_TTL_MS });
-
-  try {
-    return await promise;
-  } catch (err) {
-    // Never leave a rejection cached, or the failure sticks for the whole TTL.
-    cache.delete(url);
-    throw err;
-  }
-};
 
 router.get("/:query", requireAuth, async (req, res) => {
   const { query } = req.params;
@@ -111,7 +40,7 @@ router.get("/:query", requireAuth, async (req, res) => {
   }
 
   try {
-    const data = await fetchSquiggle(buildUrl(query, params));
+    const data = await squiggle.query(query, params);
     res.status(200).json(data);
   } catch (err) {
     console.error("Squiggle proxy failed:", err.message);

--- a/scripts/syncSeason.js
+++ b/scripts/syncSeason.js
@@ -1,0 +1,41 @@
+// Loads a season from Squiggle into MongoDB from the command line:
+//
+//   node scripts/syncSeason.js 2026
+//
+// Handy for seeding a fresh database, and the obvious thing to point a
+// scheduled job at so the data stays current without anyone opening the app.
+
+const mongoose = require("mongoose");
+require("dotenv").config();
+
+const seasonSync = require("../services/seasonSync");
+const squiggle = require("../services/squiggle");
+
+const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost/twin-tips";
+
+(async () => {
+  const year = Number(process.argv[2]) || new Date().getFullYear();
+
+  if (!squiggle.hasContact()) {
+    console.warn(
+      "SQUIGGLE_CONTACT is not set - Squiggle asks for a contact address in " +
+        "the UserAgent and may refuse or ban requests without one."
+    );
+  }
+
+  await mongoose.connect(MONGODB_URI);
+  console.log(`Syncing ${year} from Squiggle...`);
+
+  try {
+    const result = await seasonSync.syncSeason(year);
+    console.log(
+      `Done: ${result.games} games, ${result.teams} teams, ` +
+        `${result.standings} ladder entries for ${result.year}.`
+    );
+  } catch (err) {
+    console.error("Sync failed:", err.message);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+  }
+})();

--- a/server.js
+++ b/server.js
@@ -47,6 +47,7 @@ async function start() {
 
   app.use("/api/auth", require("./routes/api/auth"));
   app.use("/api/squiggle", require("./routes/squiggle"));
+  app.use("/api/season", require("./routes/season"));
 
   // Import routes and give the server access to them.
   require("./routes/api-routes.js")(app);

--- a/services/season.js
+++ b/services/season.js
@@ -1,0 +1,135 @@
+// Works out which season and round the competition is in, and whether tipping
+// can run at all.
+//
+// Twin Tips asks you to pick one team from the top 8 of the ladder and one from
+// the bottom 10. That only makes sense during the home-and-away season: in
+// finals just the top eight play, and from the semi-finals onward the teams are
+// not even known yet. So finals rounds are reported with tipping closed rather
+// than shown as an empty round.
+
+const db = require("../models");
+
+// Squiggle names home-and-away rounds "Round N" and everything else
+// descriptively - "Wildcard Finals", "Finals Week 1", "Semi-Finals",
+// "Preliminary Finals", "Grand Final".
+const isFinalsRoundName = (roundname) =>
+  Boolean(roundname) && /final/i.test(roundname);
+
+// is_final is a finals-type code, not a flag: 0 for home-and-away, and 2-7 for
+// the various finals. Any non-zero value counts. roundname is kept as a
+// fallback for fixtures stored before roundname was persisted.
+const isFinalsFixture = (fixture) => {
+  if (!fixture) return false;
+  if (Number(fixture.is_final) > 0) return true;
+  return isFinalsRoundName(fixture.roundname);
+};
+
+// The season to show: the most recent year we hold fixtures for. Deliberately
+// derived from the data rather than the clock, so the app keeps working through
+// the off-season instead of pointing at a year that has no fixtures yet.
+const resolveSeason = async (requested) => {
+  if (requested !== undefined && requested !== null && requested !== "") {
+    const year = Number(requested);
+    if (Number.isInteger(year)) return year;
+  }
+
+  const latest = await db.Fixture.findOne({}).sort({ year: -1 }).select("year");
+  return latest ? latest.year : new Date().getFullYear();
+};
+
+// `now` is injectable so the mid-season paths can be tested without waiting for
+// a season to come round.
+const getSeasonState = async (requestedSeason, now = new Date()) => {
+  const season = await resolveSeason(requestedSeason);
+
+  const fixtures = await db.Fixture.find({ year: season }).sort({ date: 1 });
+
+  if (!fixtures.length) {
+    return {
+      season,
+      hasFixtures: false,
+      currentRound: null,
+      roundName: null,
+      isFinals: false,
+      tippingOpen: false,
+      homeAndAwayComplete: false,
+      seasonComplete: false,
+      lockout: true,
+      firstRound: null,
+      lastHomeAndAwayRound: null,
+      message: `No fixtures loaded for ${season}.`,
+    };
+  }
+
+  const homeAndAway = fixtures.filter((f) => !isFinalsFixture(f));
+
+  const rounds = [...new Set(fixtures.map((f) => f.round))].sort((a, b) => a - b);
+  const haRounds = [...new Set(homeAndAway.map((f) => f.round))].sort(
+    (a, b) => a - b
+  );
+
+  // Round 0 is a real round in some seasons (the "Opening Round"), so the first
+  // round is whatever the data says rather than an assumed 1.
+  const firstRound = rounds.length ? rounds[0] : null;
+  const lastHomeAndAwayRound = haRounds.length ? haRounds[haRounds.length - 1] : null;
+
+  const nextFixture = fixtures.find((f) => f.date && f.date > now);
+  const lastFixture = [...fixtures].reverse().find((f) => f.date && f.date <= now);
+
+  const seasonComplete = !nextFixture;
+  const currentFixture = nextFixture || lastFixture;
+  const currentRound = currentFixture ? currentFixture.round : lastHomeAndAwayRound;
+  const roundName = currentFixture ? currentFixture.roundname || null : null;
+  const isFinals = isFinalsFixture(currentFixture);
+
+  const homeAndAwayComplete =
+    lastHomeAndAwayRound === null ||
+    !homeAndAway.some((f) => f.date && f.date > now);
+
+  // Lockout means the current round has started, so selections are frozen.
+  const roundFixtures = fixtures.filter((f) => f.round === currentRound);
+  const roundStarted = roundFixtures.some((f) => f.date && f.date <= now);
+  const lockout = seasonComplete || isFinals || roundStarted;
+
+  const tippingOpen = !seasonComplete && !isFinals && !homeAndAwayComplete && !lockout;
+
+  let message = null;
+  if (seasonComplete) {
+    message = `The ${season} season is over.`;
+  } else if (isFinals || homeAndAwayComplete) {
+    message =
+      `The ${season} home-and-away season has finished, so there is no ` +
+      `bottom 10 left to tip. Twin Tips returns next season.`;
+  } else if (lockout) {
+    message = `Round ${currentRound} has started - selections are locked.`;
+  }
+
+  return {
+    season,
+    hasFixtures: true,
+    currentRound,
+    roundName,
+    isFinals,
+    tippingOpen,
+    homeAndAwayComplete,
+    seasonComplete,
+    lockout,
+    firstRound,
+    lastHomeAndAwayRound,
+    message,
+  };
+};
+
+// Which seasons the app holds data for, newest first - drives the leaderboard's
+// season picker instead of a hardcoded list.
+const getAvailableSeasons = async () => {
+  const years = await db.Fixture.distinct("year");
+  return years.filter((y) => Number.isInteger(y)).sort((a, b) => b - a);
+};
+
+module.exports = {
+  getSeasonState,
+  getAvailableSeasons,
+  isFinalsRoundName,
+  isFinalsFixture,
+};

--- a/services/seasonSync.js
+++ b/services/seasonSync.js
@@ -1,0 +1,72 @@
+// Loads a season's data from Squiggle into MongoDB.
+//
+// This used to happen in the browser: DashboardPage noticed the standings were
+// stale, downloaded them from Squiggle, and POSTed them back to endpoints that
+// begin with deleteMany. That made every signed-in visitor capable of wiping
+// shared data, and it stopped working entirely once Squiggle began refusing
+// browser requests. Doing it here keeps the privileged writes on the server.
+
+const db = require("../models");
+const squiggle = require("./squiggle");
+
+const syncTeams = async () => {
+  const { teams } = await squiggle.query("teams");
+  if (!Array.isArray(teams) || !teams.length) {
+    throw new Error("Squiggle returned no teams");
+  }
+
+  await Promise.all(
+    teams.map((team) =>
+      db.Team.updateOne({ id: team.id }, { $set: team }, { upsert: true })
+    )
+  );
+
+  return teams.length;
+};
+
+const syncStandings = async (year) => {
+  const { standings } = await squiggle.query("standings", { year });
+  if (!Array.isArray(standings) || !standings.length) {
+    // Before a season starts there is no ladder yet; that is not a failure.
+    return 0;
+  }
+
+  await Promise.all(
+    standings.map((team) =>
+      db.Standing.updateOne({ id: team.id }, { $set: team }, { upsert: true })
+    )
+  );
+
+  return standings.length;
+};
+
+const syncGames = async (year) => {
+  const { games } = await squiggle.query("games", { year });
+  if (!Array.isArray(games) || !games.length) {
+    throw new Error(`Squiggle returned no games for ${year}`);
+  }
+
+  // Upsert by Squiggle's game id rather than deleting the season first, so a
+  // failure part-way through cannot leave the season empty.
+  await Promise.all(
+    games.map((game) =>
+      db.Fixture.updateOne({ id: game.id }, { $set: game }, { upsert: true })
+    )
+  );
+
+  return games.length;
+};
+
+const syncSeason = async (year) => {
+  if (!Number.isInteger(year)) {
+    throw new Error(`Invalid season: ${year}`);
+  }
+
+  const teams = await syncTeams();
+  const games = await syncGames(year);
+  const standings = await syncStandings(year);
+
+  return { year, teams, games, standings };
+};
+
+module.exports = { syncSeason, syncTeams, syncGames, syncStandings };

--- a/services/squiggle.js
+++ b/services/squiggle.js
@@ -1,0 +1,72 @@
+// Shared client for the Squiggle API.
+//
+// Every Squiggle call in the app goes through here: their terms forbid visitors
+// fetching directly, and they require a UserAgent identifying the app with a
+// contact address. See routes/squiggle.js (browser proxy) and
+// services/seasonSync.js (server-side data load).
+
+const SQUIGGLE_BASE = "https://api.squiggle.com.au/";
+
+// e.g. "Dan's Tipping Comp - dan@example.com". Kept in the environment rather
+// than in source because this repository is public.
+const CONTACT = process.env.SQUIGGLE_CONTACT;
+const USER_AGENT = CONTACT ? `Twin Tips - ${CONTACT}` : "Twin Tips";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map();
+
+// Squiggle separates parameters with semicolons: ?q=games;year=2026;round=5
+const buildUrl = (query, params = {}) => {
+  const parts = [`q=${query}`];
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) parts.push(`${key}=${value}`);
+  }
+  return `${SQUIGGLE_BASE}?${parts.join(";")}`;
+};
+
+const fetchUrl = async (url) => {
+  const cached = cache.get(url);
+  if (cached && Date.now() < cached.expires) {
+    return cached.promise;
+  }
+
+  const promise = (async () => {
+    const response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Squiggle responded ${response.status}`);
+    }
+
+    const body = await response.json();
+
+    // A 200 can still carry an error, e.g. {"error":"bad_UA"}. Don't cache it.
+    const first = body[Object.keys(body)[0]];
+    if (Array.isArray(first) && first.length === 1 && first[0] && first[0].error) {
+      throw new Error(`Squiggle rejected the request: ${first[0].error}`);
+    }
+
+    return body;
+  })();
+
+  // Stored before it settles so concurrent callers share one upstream request.
+  cache.set(url, { promise, expires: Date.now() + CACHE_TTL_MS });
+
+  try {
+    return await promise;
+  } catch (err) {
+    // Never leave a rejection cached, or the failure sticks for the whole TTL.
+    cache.delete(url);
+    throw err;
+  }
+};
+
+const query = (type, params) => fetchUrl(buildUrl(type, params));
+
+module.exports = {
+  query,
+  buildUrl,
+  fetchUrl,
+  hasContact: () => Boolean(CONTACT),
+};


### PR DESCRIPTION
The season was hardcoded in three places that disagreed: TipsAPI said 2023, DashboardPage defaulted to 2022 and gated result calculation on season === 2022, and the leaderboard offered 2021-2023 only. This adds a single server-side source of truth; the client still needs rewiring onto it.

services/season.js works out the season, current round, and whether tipping can run. Twin Tips asks for one team from the top 8 and one from the bottom 10, which only holds during home-and-away: in finals just the top eight play, and from the semi-finals the teams are not yet known. So finals report tippingOpen false with an explanatory message rather than presenting an unusable round.

Two assumptions in the old code were wrong for 2026:
- Round 0 is a real round (the Opening Round). The code treated 0 as "before the season started".
- Home-and-away ends at round 24, not the hardcoded 23 used as the season-over sentinel. Round counts vary by season, so the boundary is now read from the data.

is_final was declared Boolean but Squiggle sends a finals-type code - 0 home-and-away, 7 wildcard, 2/3 week one, 4 semi, 5 preliminary, 6 grand final. Mongoose rejected the real values with a CastError, so no season containing finals could ever have been stored. Now Number, with any non-zero meaning finals. roundname is persisted too as a fallback.

services/seasonSync.js loads a season from Squiggle server-side. That work used to happen in the browser: DashboardPage noticed stale standings, fetched them, and POSTed them back to endpoints beginning with deleteMany - so any signed-in visitor could wipe shared data, and it broke entirely once Squiggle started refusing browser requests. Games are upserted by Squiggle id rather than deleting the season first, so a partial failure cannot empty it. scripts/syncSeason.js runs it from the command line; POST /api/season/sync is admin-only.

services/squiggle.js is the shared client for both the browser proxy and the sync, so the required UserAgent and the response caching live in one place.

Verified against the live 2026 season (218 games loaded): state resolves to round 25 "Wildcard Finals" with tipping closed, firstRound 0 and lastHomeAndAwayRound 24. getSeasonState takes an injectable clock, so the mid-season paths are tested too - pre-season, between rounds, and mid-round all report the right round and lockout.