### PR TITLE
Read the season from the server in the client

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App';
 import AuthProvider from '../src/utils/AuthContext';
+import SeasonProvider from '../src/utils/SeasonContext';
 
 ReactDOM.render(
   <React.Fragment>
     <AuthProvider>
-      <App />
+      <SeasonProvider>
+        <App />
+      </SeasonProvider>
     </AuthProvider>
   </React.Fragment>,
 document.getElementById('root')

--- a/client/src/pages/DashboardPage/index.jsx
+++ b/client/src/pages/DashboardPage/index.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext, useEffect, useRef } from "react";
 import { AuthContext } from "../../utils/AuthContext";
+import { SeasonContext } from "../../utils/SeasonContext";
 import { Link } from "react-router-dom";
 import API from "../../utils/TipsAPI";
 import Loader from "../../components/Loader";
@@ -26,6 +27,7 @@ import calcResults from "../../utils/roundResultCalc";
 
 const Dashboard = () => {
   const { user } = useContext(AuthContext);
+  const { seasonState, availableSeasons } = useContext(SeasonContext);
   const alertRef = useRef();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -35,55 +37,28 @@ const Dashboard = () => {
   // round is round dropdown
   const [round, setRound] = useState();
   const [currentRound, setCurrentRound] = useState();
-  const [season, setSeason] = useState(2022);
+  // Follows the server rather than a year hardcoded when this page was written.
+  const [season, setSeason] = useState(null);
 
-  // run these functions on page load
+  // The season, round and lockout all come from GET /api/season now, so the
+  // page no longer works them out from fixture dates itself.
   useEffect(() => {
-    currentRoundFunction();
-  }, []);
+    if (!seasonState) return;
 
-  // what current round re we in and are we in a lockout?
-  function currentRoundFunction() {
-    API.getCurrentRound()
-      .then((results) => {
-        console.log("Upper Round: " + results.data.upperRound.round);
-        console.log("Lower Round: " + results.data.lowerRound.round);
-        if (results.data.upperRound.round === results.data.lowerRound.round) {
-          setLockout(true);
-          setRound(results.data.upperRound.round);
-          setCurrentRound(results.data.upperRound.round);
-        } else {
-          // timeAfterLastGameOfRound adds 3 hours so that the last game of the round duration is taken into account before lockout is lifted
-          const timeAfterLastGameOfRound = Moment(results.data.lowerRound.date)
-            .utcOffset(300)
-            .add(3, "hours");
-          // .format("MMMM Do, h:mm a");
-          const now = Moment();
-          // .format("MMMM Do, h:mm a");
-          console.log(
-            "now: " +
-              now +
-              " - last game +3 hrs: " +
-              timeAfterLastGameOfRound +
-              " - after last game: " +
-              (now > timeAfterLastGameOfRound) +
-              now.isAfter(timeAfterLastGameOfRound)
-          );
-          if (now > timeAfterLastGameOfRound) {
-            console.log("after last game of round");
-            setLockout(false);
-            setCurrentRound(results.data.upperRound.round);
-            setRound(results.data.upperRound.round - 1);
-          } else {
-            console.log("Its currently in the last game of the round");
-            setLockout(true);
-            setRound(results.data.upperRound.round - 1);
-            setCurrentRound(results.data.upperRound.round - 1);
-          }
-        }
-      })
-      .catch((err) => console.log(err));
-  }
+    setSeason((current) => (current === null ? seasonState.season : current));
+    setCurrentRound(seasonState.currentRound);
+    setLockout(seasonState.lockout);
+    setRound((current) =>
+      current === undefined || current === null
+        ? seasonState.currentRound
+        : current
+    );
+  }, [seasonState]);
+
+  // The round and lockout used to be reverse-engineered here from the dates of
+  // the next and previous fixtures, with a three hour fudge for match duration.
+  // GET /api/season answers both directly now, and knows about finals, so that
+  // logic lives on the server - see services/season.js.
 
   // gets squiggle fixture and writes to db
   function getRoundFixture() {
@@ -119,10 +94,16 @@ const Dashboard = () => {
     }
     // shows current round tips on top of dashboard if done
     currentRoundTips({ user: user.id, round: currentRound });
-    // calcalates results for the current round
-    // if lockout then calculates for current round
-    // below if added so calc doesnt run if selecting previous seasons
-    if (season === 2022) {
+    // Calculate results only for the live season - not for a past one picked
+    // from the dropdown, and not during finals, where the top-8/bottom-10
+    // mechanic does not apply. This used to read `season === 2022`, so it had
+    // been silently doing nothing since 2022.
+    if (
+      seasonState &&
+      season === seasonState.season &&
+      !seasonState.isFinals &&
+      !seasonState.seasonComplete
+    ) {
       if (currentRound && lockout) {
         (async function () {
           await calcResults({ round: currentRound });
@@ -142,9 +123,10 @@ const Dashboard = () => {
         })();
       }
     } else {
-      console.log("Not calculating as previous season selected");
+      console.log("Not calculating: past season, finals, or season complete");
+      loadingTimeout();
     }
-  }, [currentRound, lockout]);
+  }, [currentRound, lockout, seasonState, season]);
 
   async function roundResult(data) {
     await API.getRoundResult(data)
@@ -221,6 +203,16 @@ const Dashboard = () => {
     }, 300);
   };
 
+  // Rounds the user can look back at: from the season's first round (0 where
+  // there is an Opening Round) up to the current one.
+  const roundOptions = [];
+  if (seasonState && seasonState.currentRound !== null) {
+    const from = seasonState.firstRound !== null ? seasonState.firstRound : 1;
+    for (let r = from; r <= seasonState.currentRound; r += 1) {
+      roundOptions.push(r);
+    }
+  }
+
   const classes = useStyles();
   return (
     <div>
@@ -250,88 +242,19 @@ const Dashboard = () => {
               <InputLabel id="select-round">Round</InputLabel>
               <Select
                 labelId="select-round"
-                value={round ? round : ""}
+                // Round 0 is falsy, so check for null rather than truthiness.
+                value={round === undefined || round === null ? "" : round}
                 onChange={roundHandleChange}
               >
-                <MenuItem value={1}>Round 1</MenuItem>
-                {currentRound < 2 ? "" : <MenuItem value={2}>Round 2</MenuItem>}
-                {currentRound < 3 ? "" : <MenuItem value={3}>Round 3</MenuItem>}
-                {currentRound < 4 ? "" : <MenuItem value={4}>Round 4</MenuItem>}
-                {currentRound < 5 ? "" : <MenuItem value={5}>Round 5</MenuItem>}
-                {currentRound < 6 ? "" : <MenuItem value={6}>Round 6</MenuItem>}
-                {currentRound < 7 ? "" : <MenuItem value={7}>Round 7</MenuItem>}
-                {currentRound < 8 ? "" : <MenuItem value={8}>Round 8</MenuItem>}
-                {currentRound < 9 ? "" : <MenuItem value={9}>Round 9</MenuItem>}
-                {currentRound < 10 ? (
-                  ""
-                ) : (
-                  <MenuItem value={10}>Round 10</MenuItem>
-                )}
-                {currentRound < 11 ? (
-                  ""
-                ) : (
-                  <MenuItem value={11}>Round 11</MenuItem>
-                )}
-                {currentRound < 12 ? (
-                  ""
-                ) : (
-                  <MenuItem value={12}>Round 12</MenuItem>
-                )}
-                {currentRound < 13 ? (
-                  ""
-                ) : (
-                  <MenuItem value={13}>Round 13</MenuItem>
-                )}
-                {currentRound < 14 ? (
-                  ""
-                ) : (
-                  <MenuItem value={14}>Round 14</MenuItem>
-                )}
-                {currentRound < 15 ? (
-                  ""
-                ) : (
-                  <MenuItem value={15}>Round 15</MenuItem>
-                )}
-                {currentRound < 16 ? (
-                  ""
-                ) : (
-                  <MenuItem value={16}>Round 16</MenuItem>
-                )}
-                {currentRound < 17 ? (
-                  ""
-                ) : (
-                  <MenuItem value={17}>Round 17</MenuItem>
-                )}
-                {currentRound < 18 ? (
-                  ""
-                ) : (
-                  <MenuItem value={18}>Round 18</MenuItem>
-                )}
-                {currentRound < 19 ? (
-                  ""
-                ) : (
-                  <MenuItem value={19}>Round 19</MenuItem>
-                )}
-                {currentRound < 20 ? (
-                  ""
-                ) : (
-                  <MenuItem value={20}>Round 20</MenuItem>
-                )}
-                {currentRound < 21 ? (
-                  ""
-                ) : (
-                  <MenuItem value={21}>Round 21</MenuItem>
-                )}
-                {currentRound < 22 ? (
-                  ""
-                ) : (
-                  <MenuItem value={22}>Round 22</MenuItem>
-                )}
-                {currentRound < 23 ? (
-                  ""
-                ) : (
-                  <MenuItem value={23}>Round 23</MenuItem>
-                )}
+                {/* Generated from the season state: the list used to be 23
+                    hand-written entries starting at Round 1, so it could not
+                    show Round 0 (the Opening Round) and stopped at 23 even
+                    when the season ran longer. */}
+                {roundOptions.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {r === 0 ? "Opening Round" : `Round ${r}`}
+                  </MenuItem>
+                ))}
               </Select>
             </FormControl>
             {/* style={{ width: "auto" }} */}

--- a/client/src/pages/Leaderboard/index.jsx
+++ b/client/src/pages/Leaderboard/index.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import API from "../../utils/TipsAPI";
+import { SeasonContext } from "../../utils/SeasonContext";
 import Loader from "../../components/Loader";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
@@ -16,12 +17,19 @@ import Box from "@material-ui/core/Box";
 const Leaderboard = () => {
   const roundWinnings = 5;
 
+  const { seasonState, availableSeasons } = useContext(SeasonContext);
+
   const [isLoading, setIsLoading] = useState(true);
-  const [season, setSeason] = useState(2023);
+  // Starts empty and follows the server's current season, rather than opening
+  // on a year that was hardcoded when the page was written.
+  const [season, setSeason] = useState(null);
   const [userResults, setUserResults] = useState();
+
   useEffect(() => {
-    getLeaderboardFunction();
-  }, []);
+    if (seasonState && season === null) {
+      setSeason(seasonState.season);
+    }
+  }, [seasonState]);
 
   useEffect(() => {
     if (userResults) {
@@ -30,8 +38,9 @@ const Leaderboard = () => {
   }, [userResults]);
 
   useEffect(() => {
-    console.log(season);
-    getLeaderboardFunction();
+    if (season !== null) {
+      getLeaderboardFunction();
+    }
   }, [season]);
 
   function getLeaderboardFunction() {
@@ -117,9 +126,13 @@ const Leaderboard = () => {
                 value={season ? season : ""}
                 onChange={seasonHandleChange}
               >
-                <MenuItem value={2023}>2023</MenuItem>
-                <MenuItem value={2022}>2022</MenuItem>
-                <MenuItem value={2021}>2021</MenuItem>
+                {/* Driven by whatever seasons the database actually holds, so
+                    a new season appears here on its own. */}
+                {availableSeasons.map((year) => (
+                  <MenuItem key={year} value={year}>
+                    {year}
+                  </MenuItem>
+                ))}
               </Select>
             </FormControl>
             <Table aria-label="simple table">

--- a/client/src/pages/TipsPage/index.jsx
+++ b/client/src/pages/TipsPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext, useRef } from "react";
 import { AuthContext } from "../../utils/AuthContext";
-import { useHistory } from "react-router-dom";
+import { SeasonContext } from "../../utils/SeasonContext";
+import { useHistory, Link } from "react-router-dom";
 import FixtureCard from "../../components/FixtureCard";
 import LockoutAlert from "../../components/LockoutAlert";
 import Loader from "../../components/Loader";
@@ -22,6 +23,7 @@ import Moment from "moment";
 
 const TipsPage = () => {
   const { user } = useContext(AuthContext);
+  const { seasonState } = useContext(SeasonContext);
   const history = useHistory();
   const alertRef = useRef();
 
@@ -153,10 +155,13 @@ const TipsPage = () => {
     }
   }, [round]);
 
-  // run these functions on page load
+  // Round and lockout come from the server's season state.
   useEffect(() => {
-    currentRoundFunction();
-  }, []);
+    if (!seasonState) return;
+    setCurrentRound(seasonState.currentRound);
+    setRound(seasonState.currentRound);
+    setLockout(seasonState.lockout);
+  }, [seasonState]);
 
   useEffect(() => {
     if (currentRound) {
@@ -189,40 +194,9 @@ const TipsPage = () => {
     });
   }
 
-  // compares the time now to get what current round we are in
-  function currentRoundFunction() {
-    API.getCurrentRound()
-      .then((results) => {
-        console.log(results.data.upperRound.round);
-        console.log(results.data.lowerRound.round);
-        if (results.data.upperRound.round === results.data.lowerRound.round) {
-          setLockout(true);
-          setRound(results.data.upperRound.round);
-          setCurrentRound(results.data.upperRound.round);
-        } else {
-          // timeAfterLastGameOfRound adds 3 hours so that the last game of the round duration is taken into account before lockout is lifted
-          const timeAfterLastGameOfRound = Moment(results.data.lowerRound.date)
-            .utcOffset(300)
-            .add(3, "hours");
-          // .format("MMMM Do, h:mm a");
-          const now = Moment();
-          // .format("MMMM Do, h:mm a");
-          console.log(now > timeAfterLastGameOfRound);
-          if (now > timeAfterLastGameOfRound) {
-            console.log("after last game of round");
-            setLockout(false);
-            setCurrentRound(results.data.upperRound.round);
-            setRound(results.data.upperRound.round);
-          } else {
-            console.log("Its currently in the last game of the round");
-            setLockout(true);
-            setRound(results.data.upperRound.round - 1);
-            setCurrentRound(results.data.upperRound.round - 1);
-          }
-        }
-      })
-      .catch((err) => console.log(err));
-  }
+  // The round and lockout came from comparing fixture dates here, with a three
+  // hour allowance for match duration. GET /api/season reports both directly
+  // now, and unlike this code it understands finals - see services/season.js.
 
   useEffect(() => {
     // updates round fixture/result
@@ -251,6 +225,16 @@ const TipsPage = () => {
     }, 100);
   };
 
+  // Selectable rounds, from the season's first (0 where there is an Opening
+  // Round) to the current one.
+  const roundOptions = [];
+  if (seasonState && seasonState.currentRound !== null) {
+    const from = seasonState.firstRound !== null ? seasonState.firstRound : 1;
+    for (let r = from; r <= seasonState.currentRound; r += 1) {
+      roundOptions.push(r);
+    }
+  }
+
   const useStyles = makeStyles((theme) => ({
     formControl: {
       margin: theme.spacing(1),
@@ -267,6 +251,26 @@ const TipsPage = () => {
     <div>
       {isLoading ? (
         <Loader />
+      ) : seasonState && !seasonState.tippingOpen ? (
+        // Without this the page rendered empty whenever tipping was closed:
+        // the fixtures it wanted did not exist, or the round was a final with
+        // no bottom 10 to pick from. Say so instead of showing nothing.
+        <Container className="container" maxWidth="md">
+          <h4>{user.name}'s Tips</h4>
+          <Box boxShadow={3} mb={2} p={2} className="Box">
+            <h5>
+              {seasonState.roundName
+                ? `${seasonState.season} - ${seasonState.roundName}`
+                : `${seasonState.season} season`}
+            </h5>
+            <p>{seasonState.message}</p>
+            <p>
+              You can still review past rounds on the{" "}
+              <Link to="/dashboard">dashboard</Link> and see where everyone
+              finished on the <Link to="/leaderboard">leaderboard</Link>.
+            </p>
+          </Box>
+        </Container>
       ) : (
         <Container className="container" maxWidth="md">
           <h4>{user.name}'s Tips</h4>
@@ -282,32 +286,18 @@ const TipsPage = () => {
                   <InputLabel id="select-round">Round</InputLabel>
                   <Select
                     labelId="select-round"
-                    value={round ? round : ""}
+                    // Round 0 is falsy, so check for null explicitly.
+                    value={round === undefined || round === null ? "" : round}
                     onChange={handleChange}
                   >
-                    <MenuItem value={1}>Round 1</MenuItem>
-                    <MenuItem value={2}>Round 2</MenuItem>
-                    <MenuItem value={3}>Round 3</MenuItem>
-                    <MenuItem value={4}>Round 4</MenuItem>
-                    <MenuItem value={5}>Round 5</MenuItem>
-                    <MenuItem value={6}>Round 6</MenuItem>
-                    <MenuItem value={7}>Round 7</MenuItem>
-                    <MenuItem value={8}>Round 8</MenuItem>
-                    <MenuItem value={9}>Round 9</MenuItem>
-                    <MenuItem value={10}>Round 10</MenuItem>
-                    <MenuItem value={11}>Round 11</MenuItem>
-                    <MenuItem value={12}>Round 12</MenuItem>
-                    <MenuItem value={13}>Round 13</MenuItem>
-                    <MenuItem value={14}>Round 14</MenuItem>
-                    <MenuItem value={15}>Round 15</MenuItem>
-                    <MenuItem value={16}>Round 16</MenuItem>
-                    <MenuItem value={17}>Round 17</MenuItem>
-                    <MenuItem value={18}>Round 18</MenuItem>
-                    <MenuItem value={19}>Round 19</MenuItem>
-                    <MenuItem value={20}>Round 20</MenuItem>
-                    <MenuItem value={21}>Round 21</MenuItem>
-                    <MenuItem value={22}>Round 22</MenuItem>
-                    <MenuItem value={23}>Round 23</MenuItem>
+                    {/* Generated from the season state rather than a fixed
+                        list of 23, which could not represent an Opening
+                        Round or a season with more rounds. */}
+                    {roundOptions.map((r) => (
+                      <MenuItem key={r} value={r}>
+                        {r === 0 ? "Opening Round" : `Round ${r}`}
+                      </MenuItem>
+                    ))}
                   </Select>
                 </FormControl>
               </Grid>

--- a/client/src/utils/SeasonAPI.js
+++ b/client/src/utils/SeasonAPI.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+export default {
+  // Which season and round the app is in, and whether tipping can run.
+  getState: function (season) {
+    const query = season ? `?season=${season}` : "";
+    return axios.get(`/api/season${query}`);
+  },
+
+  // Seasons the database holds fixtures for, newest first.
+  getAvailable: function () {
+    return axios.get("/api/season/available");
+  },
+};

--- a/client/src/utils/SeasonContext.jsx
+++ b/client/src/utils/SeasonContext.jsx
@@ -1,0 +1,59 @@
+import React, { createContext, useState, useEffect, useContext } from "react";
+import SeasonAPI from "./SeasonAPI";
+import TipsAPI from "./TipsAPI";
+import { AuthContext } from "./AuthContext";
+
+export const SeasonContext = createContext();
+
+// Holds the season state the server reports, so no component has to guess which
+// year it is. TipsAPI is told the season too, since it is a plain module rather
+// than a component and cannot read context.
+export default ({ children }) => {
+  const { user } = useContext(AuthContext);
+  const [seasonState, setSeasonState] = useState(null);
+  const [availableSeasons, setAvailableSeasons] = useState([]);
+  const [isLoadingSeason, setIsLoadingSeason] = useState(false);
+
+  useEffect(() => {
+    // The season endpoints require a session, so wait until there is one.
+    if (!user.isAuthenticated) {
+      setSeasonState(null);
+      setAvailableSeasons([]);
+      TipsAPI.setSeason(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingSeason(true);
+
+    SeasonAPI.getState()
+      .then((res) => {
+        if (cancelled) return;
+        setSeasonState(res.data);
+        // Set before any page fetches, so requests carry the right year.
+        TipsAPI.setSeason(res.data.season);
+      })
+      .catch((err) => console.log(err))
+      .finally(() => {
+        if (!cancelled) setIsLoadingSeason(false);
+      });
+
+    SeasonAPI.getAvailable()
+      .then((res) => {
+        if (!cancelled) setAvailableSeasons(res.data.seasons || []);
+      })
+      .catch((err) => console.log(err));
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user.isAuthenticated]);
+
+  return (
+    <SeasonContext.Provider
+      value={{ seasonState, availableSeasons, isLoadingSeason }}
+    >
+      {children}
+    </SeasonContext.Provider>
+  );
+};

--- a/client/src/utils/TipsAPI.js
+++ b/client/src/utils/TipsAPI.js
@@ -1,12 +1,26 @@
 import axios from "axios";
 
-const season = "2023";
+// The season is no longer hardcoded here. SeasonProvider sets it from
+// GET /api/season once the user is signed in, so the server decides which
+// season the app is in. Where it is still null the request simply omits it and
+// the server falls back to the current season, which keeps a stale build from
+// pinning the app to whatever year it shipped with.
+let season = null;
+
+export const setSeason = (value) => {
+  season = value;
+};
+
+export const getSeason = () => season;
 
 // Squiggle is reached through our own server, never directly: their terms forbid
 // visitors fetching from them, and they enforce it with an origin allowlist plus
 // a required User-Agent that a browser cannot set. See routes/squiggle.js.
 
 export default {
+  setSeason,
+  getSeason,
+
   getFixture: function () {
     return axios.get(`/api/squiggle/games?year=${season}`);
   },

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -3,6 +3,28 @@ const mongoose = require("mongoose");
 const passport = require("passport");
 const moment = require("moment");
 const { requireAuth, requireAdmin } = require("../middleware/auth");
+const seasonService = require("../services/season");
+
+// The season the client asked for, or the current one when it didn't ask. Keeps
+// a stale client from pinning the app to whatever year it was built with.
+const resolveSeason = async (value) => {
+  // Deliberately strict: Number(null) and Number("") are both 0, which would
+  // otherwise sail through Number.isInteger and query season 0.
+  if (value !== null && value !== undefined && value !== "") {
+    const year = Number(value);
+    if (Number.isInteger(year) && year > 1900) return year;
+  }
+  const state = await seasonService.getSeasonState();
+  return state.season;
+};
+
+// Round numbers arrive from the client, so coerce rather than trusting them:
+// round 0 is legitimate (the Opening Round), hence the Number.isInteger check
+// rather than a truthiness test.
+const asRound = (value) => {
+  const round = Number(value);
+  return Number.isInteger(round) ? round : null;
+};
 
 // const hoursToOffset = 102;
 const hoursToOffset = 0;
@@ -100,10 +122,14 @@ module.exports = function (app) {
   });
 
   // gets fixtures with team details and standings for a particular round
-  app.post("/api/detailsRound", requireAuth, function (req, res) {
-    const apiData = req.body;
-    // console.log(apiData);
-    db.Fixture.find(apiData)
+  app.post("/api/detailsRound", requireAuth, async function (req, res) {
+    // Built field by field: the whole request body used to be handed to find(),
+    // so a client could send query operators and shape the result set.
+    const query = { year: await resolveSeason(req.body.year) };
+    const round = asRound(req.body.round);
+    if (round !== null) query.round = round;
+
+    db.Fixture.find(query)
       .sort({ date: 1 })
       .populate("home-team")
       .populate("away-team")
@@ -227,10 +253,12 @@ module.exports = function (app) {
   // .format("dddd MMMM Do YYYY, h:mm a");
 
   // gets results from the previous round
-  app.post("/api/roundResult", requireAuth, function (req, res) {
+  app.post("/api/roundResult", requireAuth, async function (req, res) {
     const apiData = req.body;
-    // console.log(apiData);
-    db.Tip.find({ round: apiData.round, season: apiData.season })
+    db.Tip.find({
+      round: asRound(apiData.round),
+      season: await resolveSeason(apiData.season),
+    })
       .populate({ path: "userDetail" })
       .then((data) => {
         // console.log(data);
@@ -242,14 +270,13 @@ module.exports = function (app) {
   });
 
   // gets current round tips for user
-  app.post("/api/userRoundTips", requireAuth, function (req, res) {
+  app.post("/api/userRoundTips", requireAuth, async function (req, res) {
     const apiData = req.body;
-    // console.log(apiData);
     db.Tip.findOne({
       // Own tips only - tips are meant to be private until lockout.
       user: req.user.id,
-      round: apiData.data.round,
-      season: apiData.season,
+      round: asRound(apiData.data && apiData.data.round),
+      season: await resolveSeason(apiData.season),
     })
       .then((data) => {
         // console.log(data);
@@ -261,16 +288,19 @@ module.exports = function (app) {
   });
 
   // gets all results
-  app.post("/api/calculateResults", requireAuth, function (req, res) {
-    const resultRound = req.body;
-    // console.log(resultRound);
-    console.log({ round: resultRound.round, season: resultRound.year });
-    db.Fixture.find(resultRound)
+  app.post("/api/calculateResults", requireAuth, async function (req, res) {
+    // Same as detailsRound: the raw body used to be the query.
+    const year = await resolveSeason(req.body.year);
+    const round = asRound(req.body.round);
+    const query = { year };
+    if (round !== null) query.round = round;
+
+    db.Fixture.find(query)
       .sort({ date: 1 })
       .then((fixture) =>
         db.Tip.find({
-          round: resultRound.round,
-          season: resultRound.year,
+          round: round,
+          season: year,
         }).then((tips) => {
           const data = { data: { fixture, tips } };
           // console.log(data);
@@ -332,10 +362,8 @@ module.exports = function (app) {
   });
 
   // gets leaderboard info
-  app.post("/api/leaderboard/", requireAuth, function (req, res) {
-    const apiData = req.body;
-    // console.log(apiData.season);
-    db.Tip.find({ season: apiData.season })
+  app.post("/api/leaderboard/", requireAuth, async function (req, res) {
+    db.Tip.find({ season: await resolveSeason(req.body.season) })
       .sort({ user: 1 })
       .populate("userDetail")
       .then((data) => {


### PR DESCRIPTION
Finishes what the previous commit started: the client no longer decides what year or round it is.

SeasonProvider fetches GET /api/season once there is a session and hands the result to the pages, and to TipsAPI - which is a plain module and cannot read context. The hardcoded season constant is gone; where the season is still unknown the request omits it and the server falls back to the current one, so a stale build cannot pin the app to the year it shipped with.

Removed from the client:
- TipsAPI's `const season = "2023"`.
- DashboardPage's `useState(2022)` and its `if (season === 2022)` guard around result calculation. That guard had been silently skipping the calculation since 2022; it now runs for the live season only, and not during finals or after the season ends.
- Both copies of the round/lockout derivation, which compared fixture dates with a three hour allowance for match duration. The server answers both directly and, unlike that code, knows about finals.
- The hand-written round lists - 23 entries in DashboardPage and another 23 in TipsPage. They started at Round 1, so they could not represent 2026's Opening Round, and stopped at 23 in a season that runs to 24. Both are generated from the season state now.
- The leaderboard's fixed 2021-2023 list, now driven by GET /api/season/available so a new season appears on its own.

The Tips page rendered blank whenever tipping was closed, because the fixtures it wanted did not exist or the round was a final with no bottom 10 to choose from. It now explains the state and points at the dashboard and leaderboard.

Two round-zero bugs: `value={round ? round : ""}` blanked the round selector on round 0, and the season resolver accepted Number(null) and Number("") as 0, which would have queried season 0. Both fixed.

While in these handlers: /api/detailsRound and /api/calculateResults passed the whole request body to find(), so a client could send query operators and shape the result set. Both now build the query from a round and a year.

Verified against the live 2026 season: the dashboard reports Round 25 and requests year=2026&round=25 rather than the old year=2023, the leaderboard opens on 2026, and the Tips page shows "2026 - Wildcard Finals" with the explanation instead of an empty page. No console errors.