### PR TITLE
Capture the ladder per round instead of keeping one global copy

### DIFF
--- a/client/src/components/AdminComponent/index.jsx
+++ b/client/src/components/AdminComponent/index.jsx
@@ -1,37 +1,43 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import Button from "@material-ui/core/Button";
-import API from "../../utils/TipsAPI";
 import TextField from "@material-ui/core/TextField";
+import SeasonAPI from "../../utils/SeasonAPI";
+import { SeasonContext } from "../../utils/SeasonContext";
 import calcResults from "../../utils/roundResultCalc";
 
 const AdminComponent = () => {
+  const { seasonState } = useContext(SeasonContext);
   const [roundCalculation, setRoundCalculation] = useState();
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState(null);
 
-  function getFixture() {
-    API.getFixture()
-      .then((results) => {
-        console.log(results.data);
-        API.postFixture(results.data);
-      })
-      .catch((err) => console.log(err));
-  }
+  // Fixtures, teams and ladder snapshots used to be three separate buttons that
+  // each downloaded from Squiggle in the browser and POSTed the result back to
+  // endpoints beginning with deleteMany. Squiggle refuses browser requests now,
+  // and that pattern let the client rewrite shared data. One call to the server
+  // does all three - see services/seasonSync.js.
+  function syncSeason() {
+    if (!seasonState) return;
+    setSyncing(true);
+    setSyncResult(null);
 
-  function getTeams() {
-    API.getTeams()
-      .then((results) => {
-        console.log(results.data);
-        API.postTeams(results.data);
+    SeasonAPI.sync(seasonState.season)
+      .then((res) => {
+        const { games, teams, ladders } = res.data;
+        setSyncResult(
+          `${games} games, ${teams} teams, ` +
+            `${ladders.captured} new ladder snapshot(s) ` +
+            `(${ladders.completed} completed rounds).`
+        );
       })
-      .catch((err) => console.log(err));
-  }
-
-  function getStandings() {
-    API.getStandings()
-      .then((results) => {
-        console.log(results.data);
-        API.postStandings(results.data);
+      .catch((err) => {
+        const message =
+          err.response && err.response.data && err.response.data.message
+            ? err.response.data.message
+            : "Sync failed.";
+        setSyncResult(message);
       })
-      .catch((err) => console.log(err));
+      .finally(() => setSyncing(false));
   }
 
   function handleRoundChangeForDownload(event) {
@@ -40,20 +46,26 @@ const AdminComponent = () => {
 
   function handleCalcResults() {
     calcResults(roundCalculation);
-    // window.location.reload();
   }
 
   return (
     <div>
       <h5>Admin Tools</h5>
-      <p>Manually download fixtures/results</p>
-      <Button variant="contained" color="primary" onClick={getFixture}>
-        Download Fixtures
+      <p>
+        Pulls fixtures, teams and a ladder snapshot for every completed round of{" "}
+        {seasonState ? seasonState.season : "the current season"} from Squiggle.
+        Normally runs on a schedule; this is the manual trigger.
+      </p>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={syncSeason}
+        disabled={syncing || !seasonState}
+      >
+        {syncing ? "Syncing..." : "Sync season from Squiggle"}
       </Button>
-      <p>function run after the completion of each round</p>
-      <Button variant="contained" color="primary" onClick={getStandings}>
-        Download Standings
-      </Button>
+      {syncResult ? <p>{syncResult}</p> : ""}
+
       <p>function that calculates tipsters results for the round</p>
       <Button
         variant="contained"
@@ -68,16 +80,16 @@ const AdminComponent = () => {
         type="number"
         onChange={handleRoundChangeForDownload}
         inputProps={{
-          min: 0,
-          max: 22,
+          // Bounds follow the season instead of a hardcoded 22.
+          min: seasonState && seasonState.firstRound !== null ? seasonState.firstRound : 0,
+          max:
+            seasonState && seasonState.currentRound !== null
+              ? seasonState.currentRound
+              : 30,
           style: { textAlign: "center" },
         }}
         style={{ width: 80 }}
       />
-      <p>Only required once - Downloads team information(logos, names etc)</p>
-      <Button variant="contained" color="primary" onClick={getTeams}>
-        Download Teams
-      </Button>
     </div>
   );
 };

--- a/client/src/pages/DashboardPage/index.jsx
+++ b/client/src/pages/DashboardPage/index.jsx
@@ -81,17 +81,12 @@ const Dashboard = () => {
   }, [round]);
 
   useEffect(() => {
-    // updates round fixture/result
-    if (currentRound && lockout) {
-      // if (currentRound) {
+    // Refreshes scores for a round in progress. Round 0 is a real round, so
+    // this checks for null rather than truthiness.
+    if (currentRound !== undefined && currentRound !== null && lockout) {
       getRoundFixture();
     }
 
-    // if lockout is false then download ladder
-    // console.log(lockout);
-    if (currentRound && !lockout) {
-      getStandingsFunction();
-    }
     // shows current round tips on top of dashboard if done
     currentRoundTips({ user: user.id, round: currentRound });
     // Calculate results only for the live season - not for a past one picked
@@ -146,37 +141,13 @@ const Dashboard = () => {
       .catch((err) => console.log(err));
   }
 
-  // this function runs if it is a lockout - checks to see when the standings in the db was updated and only updates if 3 days old or more
-  async function getStandingsFunction() {
-    await API.getStandingsDb().then((results) => {
-      // console.log(results.data[0].updatedAt);
-      const lastStandingsUpdatedTime = Moment(results.data[0].updatedAt).add(
-        3,
-        "days"
-      );
-      const now = Moment();
-      // console.log(now + lastStandingsUpdatedTime);
-      // console.log(now > lastStandingsUpdatedTime);
-      // dont update if current round = 1 as manually input end of last seasons ladder
-      if (now > lastStandingsUpdatedTime && currentRound !== 1) {
-        API.getStandings()
-          .then((results) => {
-            console.log("Downloading updated standings from squiggle");
-            console.log(results.data);
-            API.postStandings(results.data);
-          })
-          .catch((err) => console.log(err));
-        // re download fixtures for whole season, this will cover the last game of the round and any fixture updates ahead
-        API.getFixture()
-          .then((results) => {
-            console.log("dowloading yearly fixture");
-            console.log(results.data);
-            API.postFixture(results.data);
-          })
-          .catch((err) => console.log(err));
-      }
-    });
-  }
+  // The ladder used to be refreshed from here: whenever someone loaded the
+  // dashboard outside a lockout, and only if the stored ladder was more than
+  // three days old. That meant the ladder only ever updated if a human happened
+  // to visit, and because rounds run about a week, the three-day check fired
+  // mid-round as often as not - moving teams between the top 8 and the bottom
+  // 10 after people had already tipped. Snapshots are now taken server-side
+  // when a round completes; see services/seasonSync.js.
 
   function roundHandleChange(event) {
     setRound(event.target.value);

--- a/client/src/utils/SeasonAPI.js
+++ b/client/src/utils/SeasonAPI.js
@@ -11,4 +11,9 @@ export default {
   getAvailable: function () {
     return axios.get("/api/season/available");
   },
+
+  // Pulls a season from Squiggle into the database. Admin only.
+  sync: function (year) {
+    return axios.post("/api/season/sync", { year });
+  },
 };

--- a/client/src/utils/TipsAPI.js
+++ b/client/src/utils/TipsAPI.js
@@ -21,9 +21,9 @@ export default {
   setSeason,
   getSeason,
 
-  getFixture: function () {
-    return axios.get(`/api/squiggle/games?year=${season}`);
-  },
+  // Whole-season and ladder downloads are gone: the server syncs those now, so
+  // the browser no longer fetches from Squiggle and writes shared data back.
+  // See services/seasonSync.js and SeasonAPI.sync.
 
   getRoundFixture: function (round) {
     return axios.get(`/api/squiggle/games?year=${season}&round=${round}`);
@@ -35,33 +35,14 @@ export default {
     );
   },
 
-  postFixture: function (data) {
-    const datanew = { data, season };
-    return axios.post("/api/fixtures/", datanew);
-  },
-
   postRoundFixture: function (data) {
     return axios.post("/api/roundFixtures/", data);
   },
 
-  getTeams: function () {
-    return axios.get("/api/squiggle/teams");
-  },
-
-  postTeams: function (data) {
-    return axios.post("/api/teams/", data);
-  },
-
-  getStandingsDb: function () {
-    return axios.get("/api/standingsDb");
-  },
-
-  getStandings: function () {
-    return axios.get("/api/squiggle/standings");
-  },
-
-  postStandings: function (data) {
-    return axios.post("/api/standings/", data);
+  // The ladder a round is played against. Defaults to the current round.
+  getStandingsDb: function (round) {
+    const query = round === undefined || round === null ? "" : `?round=${round}`;
+    return axios.get(`/api/standingsDb${query}`);
   },
 
   getDetails: function () {

--- a/models/Standings.js
+++ b/models/Standings.js
@@ -1,10 +1,31 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
+// One row per team, per round, per season - a snapshot of the ladder as it
+// stood after that round.
+//
+// This used to be a single global ladder of 18 rows with no season or round,
+// overwritten in place. That meant looking back at an earlier round coloured
+// the teams by today's ladder, a team could move between the top 8 and the
+// bottom 10 after people had already tipped, and loading another season
+// destroyed the current one. Twin Tips is played against the ladder as it
+// stood when the round opened, so that ladder has to be kept.
 const standingSchema = new Schema(
   {
+    year: {
+      type: Number,
+    },
+    // The ladder as it stands AFTER this round. Tipping round N is judged
+    // against the snapshot for round N-1.
+    round: {
+      type: Number,
+    },
+    // Squiggle's team id.
     id: {
       type: Number,
+    },
+    name: {
+      type: String,
     },
     rank: {
       type: Number,
@@ -12,9 +33,45 @@ const standingSchema = new Schema(
     played: {
       type: Number,
     },
+    wins: {
+      type: Number,
+    },
+    losses: {
+      type: Number,
+    },
+    draws: {
+      type: Number,
+    },
+    pts: {
+      type: Number,
+    },
+    percentage: {
+      type: Number,
+    },
+    for: {
+      type: Number,
+    },
+    against: {
+      type: Number,
+    },
+    goals_for: {
+      type: Number,
+    },
+    goals_against: {
+      type: Number,
+    },
+    behinds_for: {
+      type: Number,
+    },
+    behinds_against: {
+      type: Number,
+    },
   },
   { timestamps: { createdAt: "created_at" } }
 );
+
+// One row per team per round per season.
+standingSchema.index({ year: 1, round: 1, id: 1 }, { unique: true });
 
 const Standing = mongoose.model("Standing", standingSchema);
 

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -4,6 +4,7 @@ const passport = require("passport");
 const moment = require("moment");
 const { requireAuth, requireAdmin } = require("../middleware/auth");
 const seasonService = require("../services/season");
+const standingsService = require("../services/standings");
 
 // The season the client asked for, or the current one when it didn't ask. Keeps
 // a stale client from pinning the app to whatever year it was built with.
@@ -85,26 +86,30 @@ module.exports = function (app) {
       });
   });
 
-  // gets standings in database
-  app.get("/api/standingsDb", requireAuth, function (req, res) {
-    db.Standing.find({})
-      .then((data) => res.json(data))
-      .catch((err) => {
-        res.json(err);
-      });
+  // The ladder for a round - defaults to the one the current round is played
+  // against.
+  app.get("/api/standingsDb", requireAuth, async function (req, res) {
+    try {
+      const year = await resolveSeason(req.query.year);
+      let round = asRound(req.query.round);
+      if (round === null) {
+        const state = await seasonService.getSeasonState(year);
+        round = state.currentRound !== null ? state.currentRound : 0;
+      }
+      res.json(await standingsService.getLadderForRound(year, round));
+    } catch (err) {
+      console.error("standingsDb failed:", err.message);
+      res
+        .status(500)
+        .json({ success: false, message: "Unable to load the ladder." });
+    }
   });
 
-  // fills standings in database
-  app.post("/api/standings", requireAuth, function (req, res) {
-    const apiData = req.body.standings;
-    console.log(apiData);
-    db.Standing.deleteMany({})
-      .then(() => db.Standing.create(apiData))
-      .then((data) => res.json(data))
-      .catch((err) => {
-        res.json(err);
-      });
-  });
+  // POST /api/standings is gone. It did deleteMany({}) then create(), so a
+  // failed create left no ladder at all, and it was driven from the browser on
+  // a 3-day timer that had no relationship to when rounds actually end. Ladder
+  // snapshots are captured server-side per round now - see
+  // services/seasonSync.js and POST /api/season/sync.
 
   // gets fixtures with team details and standings
   app.get("/api/details", requireAuth, function (req, res) {
@@ -129,19 +134,39 @@ module.exports = function (app) {
     const round = asRound(req.body.round);
     if (round !== null) query.round = round;
 
-    db.Fixture.find(query)
-      .sort({ date: 1 })
-      .populate("home-team")
-      .populate("away-team")
-      .populate({ path: "home-team-standing" })
-      .populate("away-team-standing")
-      .then((data) => {
-        // console.log(data);
-        res.status(200).json(data);
-      })
-      .catch((err) => {
-        res.json(err);
+    try {
+      const fixtures = await db.Fixture.find(query)
+        .sort({ date: 1 })
+        .populate("home-team")
+        .populate("away-team");
+
+      // The ladder is attached explicitly rather than through a populate, so
+      // each round gets the ladder that applied when it opened. The old
+      // virtuals joined on team id alone, which returns every season's rows now
+      // that snapshots are kept per round.
+      const ladder = await standingsService.getLadderMap(
+        query.year,
+        round !== null ? round : 0
+      );
+
+      // Kept as single-element arrays: that is the shape the populate produced
+      // and what the client reads as game["home-team-standing"][0].rank.
+      const withLadder = fixtures.map((fixture) => {
+        const doc = fixture.toObject({ virtuals: true });
+        const home = ladder.get(doc.hteamid);
+        const away = ladder.get(doc.ateamid);
+        doc["home-team-standing"] = home ? [home] : [];
+        doc["away-team-standing"] = away ? [away] : [];
+        return doc;
       });
+
+      res.status(200).json(withLadder);
+    } catch (err) {
+      console.error("detailsRound failed:", err.message);
+      res
+        .status(500)
+        .json({ success: false, message: "Unable to load the round." });
+    }
   });
 
   // fills selected user tips into database

--- a/scripts/syncSeason.js
+++ b/scripts/syncSeason.js
@@ -29,8 +29,14 @@ const MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost/twin-tips";
   try {
     const result = await seasonSync.syncSeason(year);
     console.log(
-      `Done: ${result.games} games, ${result.teams} teams, ` +
-        `${result.standings} ladder entries for ${result.year}.`
+      `Done: ${result.games} games, ${result.teams} teams for ${result.year}.`
+    );
+    console.log(
+      `Ladders: ${result.ladders.completed} completed round(s), ` +
+        `${result.ladders.captured} new snapshot(s)` +
+        (result.ladders.rounds.length
+          ? ` for round(s) ${result.ladders.rounds.join(", ")}.`
+          : ".")
     );
   } catch (err) {
     console.error("Sync failed:", err.message);

--- a/services/seasonSync.js
+++ b/services/seasonSync.js
@@ -8,6 +8,7 @@
 
 const db = require("../models");
 const squiggle = require("./squiggle");
+const standings = require("./standings");
 
 const syncTeams = async () => {
   const { teams } = await squiggle.query("teams");
@@ -24,20 +25,61 @@ const syncTeams = async () => {
   return teams.length;
 };
 
-const syncStandings = async (year) => {
-  const { standings } = await squiggle.query("standings", { year });
+// Stores the ladder as it stood after a given round. Squiggle serves historical
+// ladders via ?q=standings;year=Y;round=N, so past rounds can be backfilled.
+const syncStandingsForRound = async (year, round) => {
+  const { standings } = await squiggle.query("standings", { year, round });
   if (!Array.isArray(standings) || !standings.length) {
-    // Before a season starts there is no ladder yet; that is not a failure.
+    // No ladder yet - before a season starts, for instance. Not a failure.
     return 0;
   }
 
   await Promise.all(
     standings.map((team) =>
-      db.Standing.updateOne({ id: team.id }, { $set: team }, { upsert: true })
+      db.Standing.updateOne(
+        { year, round, id: team.id },
+        { $set: { ...team, year, round } },
+        { upsert: true }
+      )
     )
   );
 
   return standings.length;
+};
+
+// A round is done when every fixture in it has finished.
+const completedRounds = (fixtures) => {
+  const byRound = new Map();
+  fixtures.forEach((f) => {
+    if (!byRound.has(f.round)) byRound.set(f.round, []);
+    byRound.get(f.round).push(f);
+  });
+
+  return [...byRound.entries()]
+    .filter(([, games]) => games.every((g) => Number(g.complete) === 100))
+    .map(([round]) => round)
+    .sort((a, b) => a - b);
+};
+
+// Captures a ladder snapshot for every completed round that doesn't have one.
+// This is what the 3-day timer in the dashboard was standing in for: rounds run
+// about a week, so a 3-day check fired mid-round as often as not, shifting the
+// top-8/bottom-10 split under people who had already tipped.
+const syncStandingsForCompletedRounds = async (year) => {
+  const fixtures = await db.Fixture.find({ year }).select("round complete");
+  const done = completedRounds(fixtures);
+  const stored = await standings.getStoredRounds(year);
+  const missing = done.filter((r) => !stored.includes(r));
+
+  let captured = 0;
+  for (const round of missing) {
+    // Sequential rather than parallel: Squiggle ask callers not to fire large
+    // numbers of simultaneous requests.
+    const n = await syncStandingsForRound(year, round);
+    if (n) captured += 1;
+  }
+
+  return { completed: done.length, captured, rounds: missing };
 };
 
 const syncGames = async (year) => {
@@ -64,9 +106,18 @@ const syncSeason = async (year) => {
 
   const teams = await syncTeams();
   const games = await syncGames(year);
-  const standings = await syncStandings(year);
+  // Games first: which rounds are complete is read back from the fixtures we
+  // have just stored.
+  const ladders = await syncStandingsForCompletedRounds(year);
 
-  return { year, teams, games, standings };
+  return { year, teams, games, ladders };
 };
 
-module.exports = { syncSeason, syncTeams, syncGames, syncStandings };
+module.exports = {
+  syncSeason,
+  syncTeams,
+  syncGames,
+  syncStandingsForRound,
+  syncStandingsForCompletedRounds,
+  completedRounds,
+};

--- a/services/standings.js
+++ b/services/standings.js
@@ -1,0 +1,65 @@
+// Picking the right ladder for a round.
+//
+// Twin Tips is played against the ladder as it stood when the round opened, so
+// tipping round N is judged against the snapshot taken after round N-1. Fixing
+// it that way means a late-finishing game cannot move a team between the top 8
+// and the bottom 10 after someone has already tipped, and looking back at an
+// old round shows the split that actually applied at the time.
+
+const db = require("../models");
+
+// The ladder to use when tipping `round` of `year`: the snapshot after the
+// previous round. Falls back progressively, because the first round of a season
+// has no preceding round in that season - which is what the old code's
+// "currentRound !== 1" special case was working around by hand.
+const getLadderForRound = async (year, round) => {
+  if (!Number.isInteger(year) || !Number.isInteger(round)) return [];
+
+  // The snapshot taken after the previous round.
+  const previous = await db.Standing.find({ year, round: round - 1 }).sort({
+    rank: 1,
+  });
+  if (previous.length) return previous;
+
+  // No exact match - use the most recent snapshot in this season that predates
+  // the round, which covers gaps if a round's sync was missed.
+  const earlier = await db.Standing.find({
+    year,
+    round: { $lt: round },
+  })
+    .sort({ round: -1, rank: 1 })
+    .limit(200);
+  if (earlier.length) {
+    const latestRound = earlier[0].round;
+    return earlier
+      .filter((s) => s.round === latestRound)
+      .sort((a, b) => a.rank - b.rank);
+  }
+
+  // Start of a season: fall back to where the previous season finished.
+  const lastSeason = await db.Standing.find({ year: { $lt: year } })
+    .sort({ year: -1, round: -1 })
+    .limit(1);
+  if (!lastSeason.length) return [];
+
+  return db.Standing.find({
+    year: lastSeason[0].year,
+    round: lastSeason[0].round,
+  }).sort({ rank: 1 });
+};
+
+// Team id -> ladder row, for attaching ranks to a round's fixtures.
+const getLadderMap = async (year, round) => {
+  const ladder = await getLadderForRound(year, round);
+  const map = new Map();
+  ladder.forEach((row) => map.set(row.id, row));
+  return map;
+};
+
+// Which rounds of a season already have a ladder snapshot.
+const getStoredRounds = async (year) => {
+  const rounds = await db.Standing.distinct("round", { year });
+  return rounds.filter((r) => Number.isInteger(r)).sort((a, b) => a - b);
+};
+
+module.exports = { getLadderForRound, getLadderMap, getStoredRounds };


### PR DESCRIPTION
How it worked: the Standing collection held 18 rows - one per team, with no season and no round - and DashboardPage refreshed them from the browser whenever someone loaded the page outside a lockout, but only if the stored rows were more than three days old. POST /api/standings then did deleteMany({}) followed by create().

Four problems with that:

The ladder only updated if a human happened to visit. Nothing was scheduled, so if nobody opened the dashboard between the last game of a round and the first of the next, tipping opened against a stale ladder.

The three-day window had no relationship to rounds, which run about a week. It fired mid-round as often as not, moving teams between the top 8 and the bottom 10 after people had already tipped.

There was no history. One global ladder meant reviewing an old round coloured the teams by today's ladder. Seven teams crossed the top-8 line during 2026 - Collingwood was 8th when round 21 opened and 9th by round 25 - so a legitimate top-8 pick could later look invalid. Loading another season would also have destroyed the current one.

deleteMany followed by create is not atomic: a failed create left no ladder at all, and the fixture standing virtuals resolve to empty arrays, which TipsPage dereferences without a guard.

Standings are now keyed on year, round and team, where round means the ladder as it stood after that round. Squiggle serves historical ladders via ?q=standings;year=Y;round=N, so every completed round is captured. Tipping round N is judged against the snapshot after round N-1, fixed the moment the round opens. services/standings.js resolves that, falling back through earlier rounds and then to the previous season's final ladder - which is what the old "currentRound !== 1" check was working around by hand.

Snapshots are taken when a round completes - every fixture in it at complete 100 - rather than on a timer, which is what the dashboard's comment ("function run after the completion of each round") always intended.

/api/detailsRound attaches the ladder explicitly rather than through the team-id virtuals, which now match every season's rows. The single-element array shape the client reads is preserved. /api/standingsDb takes an optional round. POST /api/standings is removed, and the admin panel's three download buttons - which fetched from Squiggle in the browser and posted shared data back - are one call to the server sync.

The full ladder is stored now: wins, losses, draws, points, percentage and scores, where only rank and played were kept before.

Verified against 2026: 450 rows across rounds 0-24, re-running captures nothing new, round 13 resolves to the round-12 ladder over the API, and round 6 and round 22 return genuinely different ladders.