### PR TITLE
Pin Node for deployment and drop dead scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,17 @@
   "version": "1.0.0",
   "description": "Mern Demo",
   "main": "server.js",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "start": "if-env NODE_ENV=production && npm run start:prod || npm run start:dev",
     "start:prod": "node server.js",
     "start:dev": "concurrently \"nodemon --ignore 'client/*'\" \"npm run client\"",
     "client": "cd client && npm run start",
-    "seed": "node scripts/seedDB.js",
+    "sync": "node scripts/syncSeason.js",
     "install": "cd client && npm install",
-    "build": "cd client && npm run build",
-    "heroku-postbuild": "npm run build"
+    "build": "cd client && npm run build"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Render picks its own Node version when package.json says nothing, and Vite needs 20 or newer, so the runtime is now pinned to the 24.x the app was built and tested on.

Removed two scripts that no longer do anything:
- heroku-postbuild, left over from the Heroku deploy. Render ignores it and takes its build command from the dashboard instead.
- seed, which pointed at scripts/seedDB.js. That file is not in the repository, so the script could only ever have failed.

Added a sync script as a shorthand for scripts/syncSeason.js, which is how a database gets its fixtures - including the one behind the deploy.