### PR TITLE
Keep results browsable once tipping closes

### DIFF
--- a/client/src/components/FixtureCard/index.jsx
+++ b/client/src/components/FixtureCard/index.jsx
@@ -58,6 +58,14 @@ const FixtureCard = ({
     event.target.style.display = "none";
   };
 
+  // Finals fixtures exist before anyone knows who is in them: the semi-finals,
+  // preliminary finals and grand final all carry empty team names and a null
+  // team id. Render the fixture without pretending there is a team.
+  const homeUndecided = !hteam;
+  const awayUndecided = !ateam;
+  const homeName = hteam || "To be decided";
+  const awayName = ateam || "To be decided";
+
   let hcolor;
   let acolor;
   if (round === currentRound && hteamrank <= 8) {
@@ -73,7 +81,11 @@ const FixtureCard = ({
 
   return (
     <div style={{ padding: "3px", height: "100%", width: "100%" }}>
-      {hteam ? (
+      {/* This was gated on hteam, so a fixture whose teams are not yet decided
+          rendered an empty div - the finals disappeared from the calendar
+          rather than showing as upcoming. The card handles undecided sides
+          now, so it only needs a fixture to exist. */}
+      {id ? (
         <Grid container direction="row" align="center" alignItems="stretch">
           <Grid item xs={3}>
             <Card variant="outlined" className={classes.fill}>
@@ -85,14 +97,18 @@ const FixtureCard = ({
                 }}
               >
                 <Grid item>
-                  <img
-                    src={`/assets/team-logos/${habrev}.svg`}
-                    alt={hteam}
-                    onError={hideBrokenLogo}
-                    style={{ maxWidth: "80px", height: "auto" }}
-                  />
+                  {homeUndecided ? (
+                    ""
+                  ) : (
+                    <img
+                      src={`/assets/team-logos/${habrev}.svg`}
+                      alt={hteam}
+                      onError={hideBrokenLogo}
+                      style={{ maxWidth: "80px", height: "auto" }}
+                    />
+                  )}
                 </Grid>
-                {hteam} {"  "}
+                {homeName} {"  "}
                 {round === currentRound && !lockout ? (
                   <FormControlLabel
                     control={
@@ -174,14 +190,18 @@ const FixtureCard = ({
                 }}
               >
                 <Grid item>
-                  <img
-                    src={`/assets/team-logos/${aabrev}.svg`}
-                    alt={ateam}
-                    onError={hideBrokenLogo}
-                    style={{ maxWidth: "80px", height: "auto" }}
-                  />
+                  {awayUndecided ? (
+                    ""
+                  ) : (
+                    <img
+                      src={`/assets/team-logos/${aabrev}.svg`}
+                      alt={ateam}
+                      onError={hideBrokenLogo}
+                      style={{ maxWidth: "80px", height: "auto" }}
+                    />
+                  )}
                 </Grid>
-                {ateam}
+                {awayName}
                 {"  "}
                 {round === currentRound && !lockout ? (
                   <FormControlLabel

--- a/client/src/components/FixtureCenterCard/index.jsx
+++ b/client/src/components/FixtureCenterCard/index.jsx
@@ -86,7 +86,10 @@ const FixtureCenterCard = ({
             {winner}
           </Typography>
           <Typography variant="subtitle1" gutterBottom>
-            {!winner ? (
+            {/* modelId guards fixtures Squiggle has no prediction for - a final
+                whose teams are not decided yet would otherwise advertise
+                "(100%) by 0 points" against two blank sides. */}
+            {!winner && modelId ? (
               homeConfidence > 50 ? (
                 <a
                   href={`https://squiggle.com.au/game/?gid=${modelId}`}

--- a/client/src/pages/TipsPage/index.jsx
+++ b/client/src/pages/TipsPage/index.jsx
@@ -141,26 +141,40 @@ const TipsPage = () => {
   //   on round state updating retrieve fixtures within that round and squiggle model api results
   // ned to add something in here so that it updates from squiggle checking results
   useEffect(() => {
-    if (round) {
-      API.getRoundDetails(round)
-        .then((results) => {
-          API.getModels(round).then((modelResults) => {
-            // console.log(modelResults.data.tips);
-            console.log(results.data);
-            setModelResults(modelResults.data.tips);
-            setRoundFixture(results.data);
-          });
-        })
-        .catch((err) => console.log(err));
-    }
+    // Round 0 is a real round, so check for null rather than truthiness.
+    if (round === undefined || round === null) return;
+
+    API.getRoundDetails(round)
+      .then((results) => {
+        setRoundFixture(results.data);
+        // Model predictions are a nice-to-have: a finals round Squiggle has no
+        // tips for should still render the fixtures.
+        return API.getModels(round)
+          .then((modelResults) => setModelResults(modelResults.data.tips))
+          .catch(() => setModelResults(undefined));
+      })
+      .catch((err) => console.log(err));
   }, [round]);
 
   // Round and lockout come from the server's season state.
   useEffect(() => {
     if (!seasonState) return;
     setCurrentRound(seasonState.currentRound);
-    setRound(seasonState.currentRound);
     setLockout(seasonState.lockout);
+
+    // When tipping is closed the page is a results view, so open on the last
+    // round that has actually been played. Opening on the current round would
+    // show an unplayed round reading 0-0 in every game.
+    if (seasonState.tippingOpen) {
+      setRound(seasonState.currentRound);
+    } else {
+      setRound(
+        seasonState.lastCompletedRound !== null &&
+          seasonState.lastCompletedRound !== undefined
+          ? seasonState.lastCompletedRound
+          : seasonState.currentRound
+      );
+    }
   }, [seasonState]);
 
   useEffect(() => {
@@ -235,6 +249,53 @@ const TipsPage = () => {
     }
   }
 
+  // Every round the season has, finals included - used when the page is a
+  // results view rather than a tipping form.
+  const allRounds = seasonState && seasonState.rounds ? seasonState.rounds : [];
+
+  const roundLabel = (r) => (r === 0 ? "Opening Round" : `Round ${r}`);
+
+  // Populated arrays can be empty: a finals fixture whose teams are not yet
+  // decided has a null team id, and a round with no ladder snapshot has no
+  // standings. Every one of these used to be read as [0]["field"], which
+  // throws on an empty array.
+  const renderFixture = (game) => {
+    const home = (game["home-team"] || [])[0] || {};
+    const away = (game["away-team"] || [])[0] || {};
+    const homeStanding = (game["home-team-standing"] || [])[0] || {};
+    const awayStanding = (game["away-team-standing"] || [])[0] || {};
+
+    return (
+      <FixtureCard
+        id={game.id}
+        modelResults={modelResults}
+        venue={game.venue}
+        hteam={game.hteam}
+        ateam={game.ateam}
+        complete={game.complete}
+        hscore={game.hscore}
+        ascore={game.ascore}
+        winner={game.winner === game.hteam ? home.abbrev : away.abbrev}
+        date={game.date}
+        round={game.round}
+        hteamlogo={home.logo}
+        ateamlogo={away.logo}
+        hteamrank={homeStanding.rank}
+        ateamrank={awayStanding.rank}
+        aabrev={away.abbrev}
+        habrev={home.abbrev}
+        key={game.id}
+        handleSelectionChange={handleSelectionChange}
+        topEightSelection={topEightSelection}
+        bottomTenSelection={bottomTenSelection}
+        currentRound={currentRound}
+        lockout={lockout}
+        lastRoundSelectionT8={lastRoundSelectionT8}
+        lastRoundSelectionB10={lastRoundSelectionB10}
+      />
+    );
+  };
+
   const useStyles = makeStyles((theme) => ({
     formControl: {
       margin: theme.spacing(1),
@@ -265,10 +326,37 @@ const TipsPage = () => {
             </h5>
             <p>{seasonState.message}</p>
             <p>
-              You can still review past rounds on the{" "}
-              <Link to="/dashboard">dashboard</Link> and see where everyone
-              finished on the <Link to="/leaderboard">leaderboard</Link>.
+              You can still see where everyone finished on the{" "}
+              <Link to="/leaderboard">leaderboard</Link>.
             </p>
+          </Box>
+
+          {/* Results stay browsable once tipping closes - otherwise the whole
+              season's scores become unreachable the moment the last round is
+              played. Opens on the last round that actually has scores, not the
+              current round, whose games may not have been played yet. */}
+          <Box boxShadow={3} mb={2} p={2} className="Box">
+            <FormControl className={classes.formControl}>
+              <InputLabel id="select-results-round">Results</InputLabel>
+              <Select
+                labelId="select-results-round"
+                value={round === undefined || round === null ? "" : round}
+                onChange={handleChange}
+              >
+                {allRounds.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {roundLabel(r)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormGroup>
+              {roundFixture && roundFixture.length ? (
+                roundFixture.map(renderFixture)
+              ) : (
+                <p>No games for that round.</p>
+              )}
+            </FormGroup>
           </Box>
         </Container>
       ) : (
@@ -323,41 +411,7 @@ const TipsPage = () => {
             </Grid>
             <FormGroup>
               {roundFixture ? (
-                roundFixture.map((game) => {
-                  return (
-                    <FixtureCard
-                      id={game.id}
-                      modelResults={modelResults}
-                      venue={game.venue}
-                      hteam={game.hteam}
-                      ateam={game.ateam}
-                      complete={game.complete}
-                      hscore={game.hscore}
-                      ascore={game.ascore}
-                      winner={
-                        game.winner === game.hteam
-                          ? game["home-team"][0]["abbrev"]
-                          : game["away-team"][0]["abbrev"]
-                      }
-                      date={game.date}
-                      round={game.round}
-                      hteamlogo={game["home-team"][0]["logo"]}
-                      ateamlogo={game["away-team"][0]["logo"]}
-                      hteamrank={game["home-team-standing"][0]["rank"]}
-                      ateamrank={game["away-team-standing"][0]["rank"]}
-                      aabrev={game["away-team"][0]["abbrev"]}
-                      habrev={game["home-team"][0]["abbrev"]}
-                      key={game.id}
-                      handleSelectionChange={handleSelectionChange}
-                      topEightSelection={topEightSelection}
-                      bottomTenSelection={bottomTenSelection}
-                      currentRound={currentRound}
-                      lockout={lockout}
-                      lastRoundSelectionT8={lastRoundSelectionT8}
-                      lastRoundSelectionB10={lastRoundSelectionB10}
-                    />
-                  );
-                })
+                roundFixture.map(renderFixture)
               ) : (
                 <FixtureCard data="No games" />
               )}

--- a/services/season.js
+++ b/services/season.js
@@ -57,6 +57,8 @@ const getSeasonState = async (requestedSeason, now = new Date()) => {
       lockout: true,
       firstRound: null,
       lastHomeAndAwayRound: null,
+      lastCompletedRound: null,
+      rounds: [],
       message: `No fixtures loaded for ${season}.`,
     };
   }
@@ -72,6 +74,19 @@ const getSeasonState = async (requestedSeason, now = new Date()) => {
   // round is whatever the data says rather than an assumed 1.
   const firstRound = rounds.length ? rounds[0] : null;
   const lastHomeAndAwayRound = haRounds.length ? haRounds[haRounds.length - 1] : null;
+
+  // The most recent round where every game has been played. Not the same as
+  // the current round: when a round is upcoming its fixtures exist with no
+  // scores, so a results view opening on currentRound would show 0-0
+  // throughout.
+  const playedRounds = rounds.filter((round) =>
+    fixtures
+      .filter((f) => f.round === round)
+      .every((f) => Number(f.complete) === 100)
+  );
+  const lastCompletedRound = playedRounds.length
+    ? playedRounds[playedRounds.length - 1]
+    : null;
 
   const nextFixture = fixtures.find((f) => f.date && f.date > now);
   const lastFixture = [...fixtures].reverse().find((f) => f.date && f.date <= now);
@@ -116,6 +131,10 @@ const getSeasonState = async (requestedSeason, now = new Date()) => {
     lockout,
     firstRound,
     lastHomeAndAwayRound,
+    lastCompletedRound,
+    // Every round the season holds, finals included, so a results view can
+    // offer them all rather than guessing at a range.
+    rounds,
     message,
   };
 };


### PR DESCRIPTION
The Tips page showed only the "season has finished" message, so the moment the last home-and-away round was played the whole season's scores became unreachable from here. A round selector and the fixtures now sit below that message.

It opens on the last round that has actually been played rather than the current round. Those are different: round 25 is the Wildcard Finals, but those games are not until 28 August, so opening on the current round would have shown 0-0 in every game. The season state reports lastCompletedRound - the highest round where every fixture reads complete 100 - and a rounds list so the selector can offer the whole season including finals.

Finals fixtures exist before anyone knows who is in them: the semi-finals, preliminary finals and grand final all carry empty team names and a null team id. Three things had to change for those:

- TipsPage read game["home-team"][0]["abbrev"] and three more like it. Those arrays are empty for an undecided fixture, and for any round with no ladder snapshot, so every one of them would have thrown. Extracted into a single guarded renderer used by both views.
- FixtureCard gated its entire body on hteam, so an undecided fixture rendered an empty div and the finals simply vanished from the calendar. It keys off the fixture id now and shows "To be decided" in place of a team, with no logo.
- FixtureCenterCard advertised "(100%) by 0 points" between two blank sides, because Squiggle has no prediction for a game whose teams are unknown. The prediction is suppressed when there is no model result.

Model predictions are also no longer able to fail the whole load: a round Squiggle has no tips for renders its fixtures regardless.

Verified against 2026: the page opens on round 24 with all nine games and real scores, round 29 shows the Grand Final as undecided with its date and venue and no phantom prediction, and neither produces a console error.