### PR TITLE
Fix the round winner and the ladder rollover between seasons

### DIFF
--- a/services/results.js
+++ b/services/results.js
@@ -53,6 +53,11 @@ const scoreSelection = (selection, predictedMargin, games) => {
 // The margin that actually counts for a tip. Exactly one of the two selections
 // carries a prediction, so use that one's difference rather than picking
 // whichever value happens to be truthy.
+//
+// Computed inside scoreTip rather than read off the result afterwards: doing it
+// afterwards needs marginTopEight, and a caller that forgets to carry that
+// field through silently gets bottomTenDifference for everyone - which drops
+// every tipster who put their margin on the top-8 pick out of contention.
 const marginDifference = (tip) => {
   const onTopEight = Number(tip.marginTopEight) > 0;
   const difference = onTopEight
@@ -69,12 +74,17 @@ const scoreTip = (tip, games) => {
     games
   );
 
+  const onTopEight = Number(tip.marginTopEight) > 0;
+  const counted = onTopEight ? top.difference : bottom.difference;
+
   return {
     topEightCorrect: top.correct,
     bottomTenCorrect: bottom.correct,
     topEightDifference: top.difference,
     bottomTenDifference: bottom.difference,
     correctTips: (top.correct ? 1 : 0) + (bottom.correct ? 1 : 0),
+    // The difference the round is decided on.
+    countedDifference: counted === undefined ? null : counted,
   };
 };
 
@@ -86,15 +96,19 @@ const pickWinners = (scored) => {
   const best = Math.max(...scored.map((s) => s.correctTips));
   const contenders = scored.filter((s) => s.correctTips === best);
 
-  const withMargin = contenders
-    .map((s) => ({ ...s, margin: marginDifference(s) }))
-    .filter((s) => s.margin !== null);
+  // countedDifference comes from scoreTip, which knows which selection the
+  // margin was put on.
+  const withMargin = contenders.filter(
+    (s) => s.countedDifference !== null && s.countedDifference !== undefined
+  );
 
   // Nobody predicted a margin, so the tip count alone decides it.
   if (!withMargin.length) return contenders.map((s) => s.user);
 
-  const closest = Math.min(...withMargin.map((s) => s.margin));
-  return withMargin.filter((s) => s.margin === closest).map((s) => s.user);
+  const closest = Math.min(...withMargin.map((s) => s.countedDifference));
+  return withMargin
+    .filter((s) => s.countedDifference === closest)
+    .map((s) => s.user);
 };
 
 // A round can only be scored once every game in it has been played.

--- a/services/seasonSync.js
+++ b/services/seasonSync.js
@@ -12,6 +12,7 @@ const db = require("../models");
 const squiggle = require("./squiggle");
 const standings = require("./standings");
 const results = require("./results");
+const season = require("./season");
 
 // Logos are stored per team abbreviation, but abbrev is a display string
 // Squiggle can change - Gold Coast went from GC to GCS, and the logo broke
@@ -96,10 +97,23 @@ const completedRounds = (fixtures) => {
 // about a week, so a 3-day check fired mid-round as often as not, shifting the
 // top-8/bottom-10 split under people who had already tipped.
 const syncStandingsForCompletedRounds = async (year) => {
-  const fixtures = await db.Fixture.find({ year }).select("round complete");
+  const fixtures = await db.Fixture.find({ year })
+    .select("round complete is_final roundname");
   const done = completedRounds(fixtures);
   const stored = await standings.getStoredRounds(year);
-  const missing = done.filter((r) => !stored.includes(r));
+
+  // Finals rounds are skipped: Squiggle stops reporting a rank once they
+  // start, so those snapshots arrive with every other field populated and no
+  // ladder position - useless for deciding who is in the top 8, and they would
+  // otherwise shadow the last real ladder when a later season falls back to
+  // "where the previous season finished".
+  const finalsRounds = new Set(
+    fixtures.filter((f) => season.isFinalsFixture(f)).map((f) => f.round)
+  );
+
+  const missing = done.filter(
+    (r) => !stored.includes(r) && !finalsRounds.has(r)
+  );
 
   let captured = 0;
   for (const round of missing) {

--- a/services/standings.js
+++ b/services/standings.js
@@ -8,6 +8,11 @@
 
 const db = require("../models");
 
+// Only ranked snapshots are usable. Squiggle stops reporting a rank once finals
+// begin - the 2025 ladders for rounds 25 to 28 have every other field but no
+// rank at all - and a ladder without ranks cannot say who is in the top 8.
+const RANKED = { rank: { $ne: null } };
+
 // The ladder to use when tipping `round` of `year`: the snapshot after the
 // previous round. Falls back progressively, because the first round of a season
 // has no preceding round in that season - which is what the old code's
@@ -16,16 +21,19 @@ const getLadderForRound = async (year, round) => {
   if (!Number.isInteger(year) || !Number.isInteger(round)) return [];
 
   // The snapshot taken after the previous round.
-  const previous = await db.Standing.find({ year, round: round - 1 }).sort({
-    rank: 1,
-  });
+  const previous = await db.Standing.find({
+    year,
+    round: round - 1,
+    ...RANKED,
+  }).sort({ rank: 1 });
   if (previous.length) return previous;
 
-  // No exact match - use the most recent snapshot in this season that predates
-  // the round, which covers gaps if a round's sync was missed.
+  // No exact match - use the most recent ranked snapshot in this season that
+  // predates the round, which covers gaps if a round's sync was missed.
   const earlier = await db.Standing.find({
     year,
     round: { $lt: round },
+    ...RANKED,
   })
     .sort({ round: -1, rank: 1 })
     .limit(200);
@@ -36,8 +44,13 @@ const getLadderForRound = async (year, round) => {
       .sort((a, b) => a.rank - b.rank);
   }
 
-  // Start of a season: fall back to where the previous season finished.
-  const lastSeason = await db.Standing.find({ year: { $lt: year } })
+  // Start of a season: fall back to where the previous season finished. That
+  // means its last home-and-away ladder, not its last round - the finals
+  // snapshots carry no ranks, so RANKED skips straight past them.
+  const lastSeason = await db.Standing.find({
+    year: { $lt: year },
+    ...RANKED,
+  })
     .sort({ year: -1, round: -1 })
     .limit(1);
   if (!lastSeason.length) return [];
@@ -45,6 +58,7 @@ const getLadderForRound = async (year, round) => {
   return db.Standing.find({
     year: lastSeason[0].year,
     round: lastSeason[0].round,
+    ...RANKED,
   }).sort({ rank: 1 });
 };
 


### PR DESCRIPTION
The winner was wrong whenever the closest margin belonged to a top-8 selection. pickWinners called marginDifference on the scored object, but that object is built from scoreTip's return, which does not carry marginTopEight - so Number(undefined) > 0 was always false and it read bottomTenDifference for everyone. Anyone who put their margin on the top-8 pick had a null there and was dropped out of contention entirely.

Round 19 of the seeded season is the example: five tipsters all on one correct tip, and it went to a margin of 35 while sample smith's 23 was discarded for having been placed on the top-8 side. This is the same mistake as the `a || b` bug it replaced, in a different disguise, and it survived because the round I spot-checked happened to have its winner's margin on the bottom-10 side.

scoreTip now works out which selection carried the margin and returns that difference as countedDifference, so nothing downstream has to reconstruct it. Every round of the seeded season is checked against an independent re-derivation rather than one round by hand.

The season rollover was also picking the wrong ladder. Squiggle stops reporting a rank once finals begin: the 2025 ladders for rounds 25 to 28 have wins, losses, points and percentage but no ladder position at all. So "where the previous season finished" resolved to the Grand Final snapshot, and every rank in it was undefined.

Finals rounds are no longer captured, since a ladder with no positions cannot say who is in the top 8, and ladder lookups ignore rankless rows. 2026 round 0 now resolves to 2025 round 24 - the last home-and-away ladder - with all 18 ranks present.

That also unblocks the season's opening round, which the seeder had been skipping for having no ladder to judge it against.

Verified across 25 rounds: no winner mismatches, scoring still idempotent, and every round pays out exactly its entrant count.