### PR TITLE
Settings: change password, favourite team, admin sync status

### DIFF
--- a/client/src/components/AdminComponent/index.jsx
+++ b/client/src/components/AdminComponent/index.jsx
@@ -1,12 +1,42 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import Button from "@material-ui/core/Button";
+import Moment from "moment";
 import SeasonAPI from "../../utils/SeasonAPI";
 import { SeasonContext } from "../../utils/SeasonContext";
+
+// Turns [0,1,2,3,7,8] into "0-3, 7-8" so a whole season's rounds fit on a line.
+const summariseRounds = (rounds) => {
+  if (!rounds || !rounds.length) return "none";
+  const sorted = [...rounds].sort((a, b) => a - b);
+  const spans = [];
+  let start = sorted[0];
+  let previous = sorted[0];
+
+  sorted.slice(1).forEach((value) => {
+    if (value !== previous + 1) {
+      spans.push([start, previous]);
+      start = value;
+    }
+    previous = value;
+  });
+  spans.push([start, previous]);
+
+  return spans.map(([a, b]) => (a === b ? `${a}` : `${a}-${b}`)).join(", ");
+};
 
 const AdminComponent = () => {
   const { seasonState } = useContext(SeasonContext);
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState(null);
+  const [status, setStatus] = useState(null);
+
+  const loadStatus = () => {
+    SeasonAPI.getStatus()
+      .then((res) => setStatus(res.data))
+      .catch((err) => console.log(err));
+  };
+
+  useEffect(loadStatus, []);
 
   // Fixtures, teams, ladder snapshots and now scoring used to be separate
   // buttons that each downloaded from Squiggle in the browser and POSTed the
@@ -35,12 +65,35 @@ const AdminComponent = () => {
             : "Sync failed.";
         setSyncResult(message);
       })
-      .finally(() => setSyncing(false));
+      .finally(() => {
+        setSyncing(false);
+        // Refresh the status line so the button's effect is visible.
+        loadStatus();
+      });
   }
+
+  const when = (value) =>
+    value ? Moment(value).format("D MMM, h:mm a") : "not since timestamps were added";
 
   return (
     <div>
       <h5>Admin Tools</h5>
+
+      {/* Enough to tell at a glance whether the scheduled sync is running,
+          without going to the server logs. */}
+      {status ? (
+        <p style={{ marginBottom: "4px" }}>
+          <strong>{status.season}</strong> &middot; fixtures updated{" "}
+          {when(status.fixturesUpdated)} &middot; ladders updated{" "}
+          {when(status.laddersUpdated)}
+          <br />
+          ladder snapshots for round(s) {summariseRounds(status.ladderRounds)}{" "}
+          &middot; scored round(s) {summariseRounds(status.scoredRounds)}
+        </p>
+      ) : (
+        ""
+      )}
+
       <p>
         Pulls fixtures, teams and a ladder snapshot for every completed round of{" "}
         {seasonState ? seasonState.season : "the current season"} from Squiggle,

--- a/client/src/pages/SettingsPage/index.jsx
+++ b/client/src/pages/SettingsPage/index.jsx
@@ -5,47 +5,119 @@ import Loader from "../../components/Loader";
 import AdminComponent from "../../components/AdminComponent";
 import Container from "@material-ui/core/Container";
 import API from "../../utils/TipsAPI";
+import AuthAPI from "../../utils/AuthAPI";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
+import TextField from "@material-ui/core/TextField";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import InputLabel from "@material-ui/core/InputLabel";
+import FormControl from "@material-ui/core/FormControl";
 
 const SettingsPage = () => {
-  const { user, logout } = useContext(AuthContext);
+  const { user, setUser } = useContext(AuthContext);
   const history = useHistory();
   const [isLoading, setIsLoading] = useState(true);
   const [userDetails, setUserDetails] = useState();
 
+  const [teams, setTeams] = useState([]);
+  const [favTeam, setFavTeam] = useState("");
+  const [teamMessage, setTeamMessage] = useState(null);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordMessage, setPasswordMessage] = useState(null);
+
+  const [deleteMessage, setDeleteMessage] = useState(null);
+
   useEffect(() => {
     getUserDetailsFunction();
+    API.getTeams()
+      .then((results) => setTeams(results.data || []))
+      .catch((err) => console.log(err));
   }, []);
 
   useEffect(() => {
     if (userDetails) {
+      setFavTeam(userDetails.favTeam);
       loadingTimeout();
     }
   }, [userDetails]);
 
   function getUserDetailsFunction() {
-    API.getUserDetails(user).then((results) => {
-      const users = results.data;
-      // console.log(users);
-      setUserDetails(users);
-    });
+    API.getUserDetails(user)
+      .then((results) => setUserDetails(results.data))
+      .catch((err) => console.log(err));
   }
 
-  function deleteUser() {
-    if (window.confirm("Are you sure you want to delete your account?")) {
-      logout();
-      API.deleteUser(user)
-        .then((response) => {
-          // console.log(response.data);
-          if (response.data.status === 200) {
-            history.go(0);
-          } else {
-            console.log(response.data.message);
-          }
-        })
-        .catch((err) => console.log(err));
+  function saveFavouriteTeam() {
+    setTeamMessage(null);
+    API.updateFavouriteTeam(favTeam)
+      .then((res) => {
+        setTeamMessage(res.data.message);
+        getUserDetailsFunction();
+      })
+      .catch((err) => setTeamMessage(errorMessage(err, "Unable to save.")));
+  }
+
+  function changePassword() {
+    setPasswordMessage(null);
+
+    if (newPassword !== confirmPassword) {
+      setPasswordMessage("The new passwords do not match.");
+      return;
     }
+
+    AuthAPI.changePassword({ currentPassword, newPassword })
+      .then((res) => {
+        setPasswordMessage(res.data.message);
+        setCurrentPassword("");
+        setNewPassword("");
+        setConfirmPassword("");
+      })
+      .catch((err) =>
+        setPasswordMessage(errorMessage(err, "Unable to change your password."))
+      );
+  }
+
+  // The old version called logout() first and then deleted, so the delete
+  // request arrived with no session, came back 401, and the account survived.
+  // It also checked response.data.status, which the endpoint has never
+  // returned, so the success branch never ran. Delete first: the server ends
+  // the session itself, leaving the client only to forget the user.
+  function deleteUser() {
+    if (!window.confirm("Are you sure you want to delete your account?")) {
+      return;
+    }
+
+    setDeleteMessage(null);
+    API.deleteUser()
+      .then((response) => {
+        if (response.data && response.data.success) {
+          setUser({
+            isAuthenticated: false,
+            name: null,
+            id: null,
+            admin: false,
+          });
+          history.push("/login");
+        } else {
+          setDeleteMessage(
+            (response.data && response.data.message) ||
+              "Unable to delete your account."
+          );
+        }
+      })
+      .catch((err) =>
+        setDeleteMessage(errorMessage(err, "Unable to delete your account."))
+      );
+  }
+
+  function errorMessage(err, fallback) {
+    return err.response && err.response.data && err.response.data.message
+      ? err.response.data.message
+      : fallback;
   }
 
   const loadingTimeout = () => {
@@ -62,26 +134,114 @@ const SettingsPage = () => {
       ) : (
         <Container className="container" maxWidth="sm">
           <h4>Settings</h4>
+
           <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">
             {userDetails ? (
               <div>
                 <h6>Name: {user.name}</h6>
                 <h6>Email: {userDetails.email}</h6>
-                <h6>Favourite Team: {userDetails.teamDetail[0].name}</h6>
-                <h6>Admin rights? {user.admin.toString()}</h6>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={deleteUser}
-                >
-                  Delete Account
-                </Button>
+                <h6>
+                  Favourite Team:{" "}
+                  {userDetails.teamDetail && userDetails.teamDetail[0]
+                    ? userDetails.teamDetail[0].name
+                    : "not set"}
+                </h6>
               </div>
             ) : (
               ""
             )}
-            {user.admin ? <AdminComponent /> : ""}
           </Box>
+
+          <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">
+            <h6>Change favourite team</h6>
+            <FormControl style={{ minWidth: 200 }}>
+              <InputLabel id="select-fav-team">Team</InputLabel>
+              <Select
+                labelId="select-fav-team"
+                value={favTeam === undefined || favTeam === null ? "" : favTeam}
+                onChange={(event) => setFavTeam(event.target.value)}
+              >
+                {teams.map((team) => (
+                  <MenuItem key={team.id} value={team.id}>
+                    {team.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>{" "}
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={saveFavouriteTeam}
+              disabled={!favTeam}
+            >
+              Save
+            </Button>
+            {teamMessage ? <p>{teamMessage}</p> : ""}
+          </Box>
+
+          <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">
+            <h6>Change password</h6>
+            <p style={{ marginTop: 0 }}>
+              Minimum eight characters, with at least one letter and one number.
+            </p>
+            <TextField
+              label="Current password"
+              type="password"
+              variant="outlined"
+              margin="dense"
+              fullWidth
+              value={currentPassword}
+              onChange={(event) => setCurrentPassword(event.target.value)}
+            />
+            <TextField
+              label="New password"
+              type="password"
+              variant="outlined"
+              margin="dense"
+              fullWidth
+              value={newPassword}
+              onChange={(event) => setNewPassword(event.target.value)}
+            />
+            <TextField
+              label="Confirm new password"
+              type="password"
+              variant="outlined"
+              margin="dense"
+              fullWidth
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+            />
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={changePassword}
+              disabled={!currentPassword || !newPassword || !confirmPassword}
+              style={{ marginTop: "8px" }}
+            >
+              Change password
+            </Button>
+            {passwordMessage ? <p>{passwordMessage}</p> : ""}
+          </Box>
+
+          <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">
+            <h6>Delete account</h6>
+            <p style={{ marginTop: 0 }}>
+              This removes your account and every tip you have entered. It
+              cannot be undone.
+            </p>
+            <Button variant="contained" color="secondary" onClick={deleteUser}>
+              Delete Account
+            </Button>
+            {deleteMessage ? <p>{deleteMessage}</p> : ""}
+          </Box>
+
+          {user.admin ? (
+            <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">
+              <AdminComponent />
+            </Box>
+          ) : (
+            ""
+          )}
         </Container>
       )}
     </div>

--- a/client/src/utils/AuthAPI.js
+++ b/client/src/utils/AuthAPI.js
@@ -20,5 +20,10 @@ export default {
     },
     resetPassword: (data) => {
         return axios.post('/api/auth/reset', data)
+    },
+    // Change your own password while signed in, as opposed to the emailed
+    // reset link, which is the only way this could be done before.
+    changePassword: (data) => {
+        return axios.post('/api/auth/password', data)
     }
 }

--- a/client/src/utils/SeasonAPI.js
+++ b/client/src/utils/SeasonAPI.js
@@ -16,4 +16,10 @@ export default {
   sync: function (year) {
     return axios.post("/api/season/sync", { year });
   },
+
+  // When the data last came down and what has been scored. Admin only.
+  getStatus: function (season) {
+    const query = season ? `?season=${season}` : "";
+    return axios.get(`/api/season/status${query}`);
+  },
 };

--- a/client/src/utils/TipsAPI.js
+++ b/client/src/utils/TipsAPI.js
@@ -94,8 +94,18 @@ export default {
     return axios.post("/api/users/", data);
   },
 
-  deleteUser: function (data) {
-    console.log(data);
-    return axios.delete("/api/deleteUser/", data);
+  // The clubs, for the favourite team picker.
+  getTeams: function () {
+    return axios.get("/api/teams");
+  },
+
+  // Only favTeam is accepted, on purpose - see the route.
+  updateFavouriteTeam: function (favTeam) {
+    return axios.patch("/api/users/me", { favTeam });
+  },
+
+  // The server identifies the account from the session, so nothing is sent.
+  deleteUser: function () {
+    return axios.delete("/api/deleteUser");
   },
 };

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -102,6 +102,46 @@ module.exports = {
             res.status(401).json({success: false, message: "Sign in required to access that route."})
         }
     },
+    // Changing your own password while signed in. Until now the only route to a
+    // new password was to log out and use the emailed reset link.
+    changePassword: async (req, res) => {
+        let { currentPassword, newPassword } = req.body;
+
+        if (!currentPassword || !newPassword) {
+            return res.status(400).json({ success: false, message: "Enter your current and new password." })
+        }
+
+        if (!validPassword(newPassword)) {
+            return res.status(400).json({ success: false, message: "Password requires a minimum of eight characters, at least one letter and one number" })
+        }
+
+        if (currentPassword === newPassword) {
+            return res.status(400).json({ success: false, message: "That is already your password." })
+        }
+
+        try {
+            // password is select:false on the schema, so ask for it explicitly.
+            const user = await db.User.findById(req.user.id).select("+password")
+
+            if (!user) {
+                return res.status(401).json({ success: false, message: "Sign in required to access that route." })
+            }
+
+            // The current password is required so that an unattended session
+            // cannot be used to lock the owner out of their own account.
+            if (!bcrypt.compareSync(currentPassword, user.password)) {
+                return res.status(403).json({ success: false, message: "Your current password is incorrect." })
+            }
+
+            const hash = bcrypt.hashSync(newPassword, bcrypt.genSaltSync(10))
+            await db.User.updateOne({ _id: user._id }, { $set: { password: hash } })
+
+            res.status(200).json({ success: true, message: "Password changed." })
+        } catch (err) {
+            console.error("changePassword failed:", err.message)
+            res.status(500).json({ success: false, message: "Unable to change your password." })
+        }
+    },
     forgotPassword: (req, res) => {
         let { email } = req.body;
         let token = crypto.randomBytes(40).toString('hex');

--- a/models/Fixtures.js
+++ b/models/Fixtures.js
@@ -76,6 +76,12 @@ const fixtureSchema = new Schema({
   id: {
     type: Number,
   },
+},
+{
+  // So the admin panel can report when the fixtures last came down from
+  // Squiggle. Existing documents have no value until the next sync rewrites
+  // them - this is not backfilled.
+  timestamps: true,
 });
 
 fixtureSchema.virtual("home-team", {

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -86,6 +86,20 @@ module.exports = function (app) {
       });
   });
 
+  // The clubs, for pickers. The teams have always been in the database but
+  // there was no way to read them back.
+  app.get("/api/teams", requireAuth, function (req, res) {
+    db.Team.find({})
+      .sort({ name: 1 })
+      .then((data) => res.json(data))
+      .catch((err) => {
+        console.error("teams lookup failed:", err.message);
+        res
+          .status(500)
+          .json({ success: false, message: "Unable to load teams." });
+      });
+  });
+
   // The ladder for a round - defaults to the one the current round is played
   // against.
   app.get("/api/standingsDb", requireAuth, async function (req, res) {
@@ -360,6 +374,39 @@ module.exports = function (app) {
       .catch((err) => {
         res.json(err);
       });
+  });
+
+  // Updates the signed-in user's own profile. Deliberately narrow: only
+  // favTeam can be set. A general "apply the body to the user" update is how
+  // register let clients grant themselves admin, so the allowed fields are
+  // named here rather than taken from the request.
+  app.patch("/api/users/me", requireAuth, async function (req, res) {
+    const favTeam = Number(req.body.favTeam);
+
+    if (!Number.isInteger(favTeam)) {
+      return res
+        .status(400)
+        .json({ success: false, message: "Choose a team." });
+    }
+
+    try {
+      const team = await db.Team.findOne({ id: favTeam });
+      if (!team) {
+        return res
+          .status(400)
+          .json({ success: false, message: "That is not a team." });
+      }
+
+      await db.User.updateOne({ _id: req.user.id }, { $set: { favTeam } });
+      res
+        .status(200)
+        .json({ success: true, message: `Favourite team set to ${team.name}.` });
+    } catch (err) {
+      console.error("profile update failed:", err.message);
+      res
+        .status(500)
+        .json({ success: false, message: "Unable to update your profile." });
+    }
   });
 
   // gets user details

--- a/routes/api/auth/index.js
+++ b/routes/api/auth/index.js
@@ -2,6 +2,7 @@ const express = require("express");
 const router = express.Router();
 const passport = require("../../../config/passport");
 const authController = require("../../../controllers/authController");
+const { requireAuth } = require("../../../middleware/auth");
 
 router
   .route("/")
@@ -44,5 +45,12 @@ router
   // @desc   POST route to reset password
   // @access Public
   .post(authController.resetPassword);
+
+router
+  .route("/password")
+  // @route  POST /api/auth/password
+  // @desc   POST change your own password while signed in
+  // @access Private
+  .post(requireAuth, authController.changePassword);
 
 module.exports = router;

--- a/routes/season.js
+++ b/routes/season.js
@@ -31,6 +31,43 @@ router.get("/available", requireAuth, async (req, res) => {
   }
 });
 
+// What the last sync actually achieved, so an admin can tell the scheduled job
+// is doing its work without reading server logs.
+router.get("/status", requireAdmin, async (req, res) => {
+  try {
+    const db = require("../models");
+    const standings = require("../services/standings");
+
+    const year = Number(req.query.season) || (await season.getSeasonState()).season;
+
+    const [newestFixture, newestLadder] = await Promise.all([
+      db.Fixture.findOne({ year }).sort({ updatedAt: -1 }).select("updatedAt"),
+      db.Standing.findOne({ year }).sort({ updatedAt: -1 }).select("updatedAt"),
+    ]);
+
+    const ladderRounds = await standings.getStoredRounds(year);
+    const scoredRounds = await db.Tip.distinct("round", {
+      season: year,
+      correctTips: { $ne: null },
+    });
+
+    res.status(200).json({
+      season: year,
+      // Null until the next sync: timestamps were added to fixtures after
+      // these documents were written.
+      fixturesUpdated: newestFixture ? newestFixture.updatedAt : null,
+      laddersUpdated: newestLadder ? newestLadder.updatedAt : null,
+      ladderRounds,
+      scoredRounds: scoredRounds.sort((a, b) => a - b),
+    });
+  } catch (err) {
+    console.error("season status failed:", err.message);
+    res
+      .status(500)
+      .json({ success: false, message: "Unable to read sync status." });
+  }
+});
+
 // Pulls a season from Squiggle into the database. Admin-only: it is the one
 // route that rewrites shared fixture, ladder and team data.
 router.post("/sync", requireAdmin, async (req, res) => {


### PR DESCRIPTION
Delete Account never deleted anything. The page called logout() before deleteUser(), so the delete request arrived with no session, came back 401, and the account survived - confirmed by driving the endpoints in that order. It also checked response.data.status === 200, a field the endpoint has never returned, so the success branch could not run either. The delete now happens while the session is still valid; the server ends the session itself, leaving the client only to forget the user. Failures are shown rather than logged to the console.

Change password: POST /api/auth/password, for signed-in users. The only way to change a password before was to log out and use the emailed reset link. The current password is required, so an unattended session cannot be used to lock the owner out, and the new one goes through the same validation as registration.

Favourite team: GET /api/teams reads back the clubs, which have always been in the database with no way to fetch them, and PATCH /api/users/me sets favTeam. That route accepts favTeam and nothing else, by name - a general "apply the body" update is how register let clients make themselves admin. Verified: sending admin:true alongside favTeam changes the team and leaves admin false.

Admin sync status: GET /api/season/status (admin only) reports when fixtures and ladders were last written, which rounds hold ladder snapshots and which have been scored, so the scheduled sync can be checked without reading server logs. Fixtures had no timestamps, so those were added - values appear from the next sync onwards rather than being backfilled.

"Admin rights? false" is removed. It told non-admins nothing they could act on, and admins can already tell by the panel below it.