### PR TITLE
Confirm account deletion with a dialog, not window.confirm

### DIFF
--- a/client/src/pages/SettingsPage/index.jsx
+++ b/client/src/pages/SettingsPage/index.jsx
@@ -13,6 +13,11 @@ import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
 import InputLabel from "@material-ui/core/InputLabel";
 import FormControl from "@material-ui/core/FormControl";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import DialogActions from "@material-ui/core/DialogActions";
 
 const SettingsPage = () => {
   const { user, setUser } = useContext(AuthContext);
@@ -30,6 +35,8 @@ const SettingsPage = () => {
   const [passwordMessage, setPasswordMessage] = useState(null);
 
   const [deleteMessage, setDeleteMessage] = useState(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     getUserDetailsFunction();
@@ -86,12 +93,15 @@ const SettingsPage = () => {
   // It also checked response.data.status, which the endpoint has never
   // returned, so the success branch never ran. Delete first: the server ends
   // the session itself, leaving the client only to forget the user.
+  // Confirmation is a dialog rather than window.confirm. The browser is free
+  // to suppress a native confirm - Chrome's "prevent this page from creating
+  // additional dialogs", sandboxed frames, background tabs - and a suppressed
+  // confirm returns false, so the delete silently did nothing with no dialog
+  // ever shown and no error to go on.
   function deleteUser() {
-    if (!window.confirm("Are you sure you want to delete your account?")) {
-      return;
-    }
-
+    setConfirmingDelete(false);
     setDeleteMessage(null);
+    setDeleting(true);
     API.deleteUser()
       .then((response) => {
         if (response.data && response.data.success) {
@@ -111,7 +121,8 @@ const SettingsPage = () => {
       })
       .catch((err) =>
         setDeleteMessage(errorMessage(err, "Unable to delete your account."))
-      );
+      )
+      .finally(() => setDeleting(false));
   }
 
   function errorMessage(err, fallback) {
@@ -229,11 +240,44 @@ const SettingsPage = () => {
               This removes your account and every tip you have entered. It
               cannot be undone.
             </p>
-            <Button variant="contained" color="secondary" onClick={deleteUser}>
-              Delete Account
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={() => setConfirmingDelete(true)}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting..." : "Delete Account"}
             </Button>
             {deleteMessage ? <p>{deleteMessage}</p> : ""}
           </Box>
+
+          <Dialog
+            open={confirmingDelete}
+            onClose={() => setConfirmingDelete(false)}
+            aria-labelledby="confirm-delete-title"
+          >
+            <DialogTitle id="confirm-delete-title">
+              Delete your account?
+            </DialogTitle>
+            <DialogContent>
+              <DialogContentText>
+                This removes {user.name}'s account and every tip entered under
+                it. It cannot be undone.
+              </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+              <Button
+                onClick={() => setConfirmingDelete(false)}
+                color="primary"
+                autoFocus
+              >
+                Cancel
+              </Button>
+              <Button onClick={deleteUser} color="secondary">
+                Delete my account
+              </Button>
+            </DialogActions>
+          </Dialog>
 
           {user.admin ? (
             <Box boxShadow={3} p={2} pt={1} mb={2} className="Box">


### PR DESCRIPTION
Delete Account did nothing when clicked. The guard was window.confirm(...), and a browser is free to suppress a native confirm - Chrome offers "prevent this page from creating additional dialogs", sandboxed frames and background tabs block them outright, and automated browsers dismiss them by default. A suppressed confirm returns false, so the handler returned early: no dialog appeared, no request was sent, no error was raised. Reproduced here, where the native confirm returned false without ever rendering.

Replaced with a Material-UI dialog, which is ordinary DOM and cannot be suppressed. It names the account being deleted, defaults focus to Cancel, and the button shows progress while the request is in flight so a slow delete does not look like another silent failure.

Verified through the interface: Cancel leaves the account intact, and confirming deletes it, ends the session and returns to sign-in.