### PR TITLE
React 16 to 18, with createRoot

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,8 +14,8 @@
         "axios": "^1.19.0",
         "fontsource-roboto": "^2.1.4",
         "moment": "^2.30.1",
-        "react": "^16.14.0",
-        "react-dom": "^16.14.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0"
       },
@@ -1561,32 +1561,28 @@
       }
     },
     "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -1686,12 +1682,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/source-map-js": {

--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,8 @@
     "axios": "^1.19.0",
     "fontsource-roboto": "^2.1.4",
     "moment": "^2.30.1",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
   },

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './components/App';
 import AuthProvider from '../src/utils/AuthContext';
 import SeasonProvider from '../src/utils/SeasonContext';
 
-ReactDOM.render(
+// createRoot replaces ReactDOM.render, which React 18 deprecated and 19
+// removed outright - calling it now throws rather than warning.
+createRoot(document.getElementById('root')).render(
   <React.Fragment>
     <AuthProvider>
       <SeasonProvider>
         <App />
       </SeasonProvider>
     </AuthProvider>
-  </React.Fragment>,
-document.getElementById('root')
+  </React.Fragment>
 );
 
 // </React.StrictMode>, change fragment to this to do some checks


### PR DESCRIPTION
ReactDOM.render is replaced by createRoot, which React 18 deprecated it in favour of and 19 removes outright.

Stopped at 18 rather than going straight to 19, having tried 19 first: the app rendered a blank page with "findDOMNode is not a function" repeating in the console. React 19 removes findDOMNode, and the Material-UI in use here still calls it through react-transition-group, so React 19 and the current Material-UI cannot run together. React 18 keeps findDOMNode, so the app works at this step rather than being broken until a much larger Material-UI migration lands with it.

That sets the order for the rest: Material-UI to @mui v7 next, which removes the findDOMNode dependency, then React 19, then react-router 7 - which needs React 18 or newer, so it was blocked until now.

Verified on a clean page load: no console errors, sign-in works and the dashboard renders its results table.